### PR TITLE
2022.02 2주차

### DIFF
--- a/README.md
+++ b/README.md
@@ -39,5 +39,6 @@ TDD 공부도 하고 Spring 프로젝트를 계속 손에 익혀본다.
         ```
 
 ## 변경사항 및 TODO
+- [2022/02/08](https://dogfooter219.notion.site/2022-02-2-b66133f5680a4094bba04662b2975ad8)
 - [2022/02/01](https://dogfooter219.notion.site/2022-02-1-7ebcb5300811407da8f3bd8dc6c13490)
 - [2022/01/20](https://dogfooter219.notion.site/2022-01-3-4-74f4f6d709d942e0a14e6dc5d587ae4a)

--- a/src/main/java/com/zoooohs/instagramclone/configuration/JwtTokenProvider.java
+++ b/src/main/java/com/zoooohs/instagramclone/configuration/JwtTokenProvider.java
@@ -80,7 +80,11 @@ public class JwtTokenProvider {
     }
 
     public String resolveToken(HttpServletRequest request) {
-        return request.getHeader("Authorization").substring("Bearer ".length());
+        String authorization = request.getHeader("Authorization");
+        if (authorization == null) {
+            return null;
+        }
+        return authorization.substring("Bearer ".length());
     }
 
     public boolean validAccessToken(String jwtToken) {

--- a/src/main/java/com/zoooohs/instagramclone/configuration/SecurityConfiguration.java
+++ b/src/main/java/com/zoooohs/instagramclone/configuration/SecurityConfiguration.java
@@ -49,7 +49,7 @@ public class SecurityConfiguration extends WebSecurityConfigurerAdapter {
                 .and()
                 .authorizeRequests()
                 .antMatchers("/auth/**").permitAll()
-                .antMatchers("/**").authenticated()
+                .anyRequest().authenticated()
                 .and()
                 .addFilterBefore(new JwtAuthenticationFilter(jwtTokenProvider), UsernamePasswordAuthenticationFilter.class);
 

--- a/src/main/java/com/zoooohs/instagramclone/domain/comment/controller/CommentController.java
+++ b/src/main/java/com/zoooohs/instagramclone/domain/comment/controller/CommentController.java
@@ -2,15 +2,15 @@ package com.zoooohs.instagramclone.domain.comment.controller;
 
 import com.zoooohs.instagramclone.domain.comment.dto.CommentDto;
 import com.zoooohs.instagramclone.domain.comment.service.CommentService;
+import com.zoooohs.instagramclone.domain.common.model.PageModel;
 import com.zoooohs.instagramclone.domain.user.dto.UserDto;
 import lombok.RequiredArgsConstructor;
 import org.springframework.security.core.annotation.AuthenticationPrincipal;
-import org.springframework.web.bind.annotation.PathVariable;
-import org.springframework.web.bind.annotation.PostMapping;
-import org.springframework.web.bind.annotation.RequestBody;
-import org.springframework.web.bind.annotation.RestController;
+import org.springframework.web.bind.annotation.*;
 
 import javax.validation.Valid;
+import javax.validation.constraints.NotNull;
+import java.util.List;
 
 @RequiredArgsConstructor
 @RestController
@@ -20,8 +20,12 @@ public class CommentController {
 
     @PostMapping("/post/{postId}/comment")
     public CommentDto create(@RequestBody @Valid CommentDto commentDto, @PathVariable Long postId, @AuthenticationPrincipal UserDto userDto) {
-        commentDto = commentService.create(commentDto, postId, userDto);
-        return commentDto;
+        return commentService.create(commentDto, postId, userDto);
+    }
+
+    @GetMapping("/post/{postId}/comment")
+    public List<CommentDto> getPostCommentList(@PathVariable Long postId, @ModelAttribute @NotNull PageModel pageModel) {
+        return commentService.getPostCommentList(postId, pageModel);
     }
 
 }

--- a/src/main/java/com/zoooohs/instagramclone/domain/comment/controller/CommentController.java
+++ b/src/main/java/com/zoooohs/instagramclone/domain/comment/controller/CommentController.java
@@ -28,4 +28,9 @@ public class CommentController {
         return commentService.getPostCommentList(postId, pageModel);
     }
 
+    @PatchMapping("/comment/{commentId}")
+    public CommentDto updateComment(@PathVariable Long commentId, @RequestBody CommentDto commentDto, @AuthenticationPrincipal UserDto userDto) {
+        return commentService.updateComment(commentId, commentDto, userDto);
+    }
+
 }

--- a/src/main/java/com/zoooohs/instagramclone/domain/comment/controller/CommentController.java
+++ b/src/main/java/com/zoooohs/instagramclone/domain/comment/controller/CommentController.java
@@ -1,0 +1,27 @@
+package com.zoooohs.instagramclone.domain.comment.controller;
+
+import com.zoooohs.instagramclone.domain.comment.dto.CommentDto;
+import com.zoooohs.instagramclone.domain.comment.service.CommentService;
+import com.zoooohs.instagramclone.domain.user.dto.UserDto;
+import lombok.RequiredArgsConstructor;
+import org.springframework.security.core.annotation.AuthenticationPrincipal;
+import org.springframework.web.bind.annotation.PathVariable;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestBody;
+import org.springframework.web.bind.annotation.RestController;
+
+import javax.validation.Valid;
+
+@RequiredArgsConstructor
+@RestController
+public class CommentController {
+
+    private final CommentService commentService;
+
+    @PostMapping("/post/{postId}/comment")
+    public CommentDto create(@RequestBody @Valid CommentDto commentDto, @PathVariable Long postId, @AuthenticationPrincipal UserDto userDto) {
+        commentDto = commentService.create(commentDto, postId, userDto);
+        return commentDto;
+    }
+
+}

--- a/src/main/java/com/zoooohs/instagramclone/domain/comment/controller/CommentController.java
+++ b/src/main/java/com/zoooohs/instagramclone/domain/comment/controller/CommentController.java
@@ -33,4 +33,10 @@ public class CommentController {
         return commentService.updateComment(commentId, commentDto, userDto);
     }
 
+    @DeleteMapping("/comment/{commentId}")
+    public Long deleteById(@PathVariable Long commentId, @AuthenticationPrincipal UserDto userDto) {
+        Long re =  commentService.deleteById(commentId, userDto);
+        return re;
+    }
+
 }

--- a/src/main/java/com/zoooohs/instagramclone/domain/comment/dto/CommentDto.java
+++ b/src/main/java/com/zoooohs/instagramclone/domain/comment/dto/CommentDto.java
@@ -1,0 +1,20 @@
+package com.zoooohs.instagramclone.domain.comment.dto;
+
+import lombok.Builder;
+import lombok.Data;
+import lombok.NoArgsConstructor;
+
+import javax.validation.constraints.NotNull;
+
+@Data
+@NoArgsConstructor
+public class CommentDto {
+    private Long id;
+    @NotNull
+    private String content;
+
+    @Builder
+    public CommentDto(String content) {
+        this.content = content;
+    }
+}

--- a/src/main/java/com/zoooohs/instagramclone/domain/comment/dto/CommentDto.java
+++ b/src/main/java/com/zoooohs/instagramclone/domain/comment/dto/CommentDto.java
@@ -1,5 +1,6 @@
 package com.zoooohs.instagramclone.domain.comment.dto;
 
+import com.zoooohs.instagramclone.domain.user.dto.UserDto;
 import lombok.Builder;
 import lombok.Data;
 import lombok.NoArgsConstructor;
@@ -13,8 +14,11 @@ public class CommentDto {
     @NotNull
     private String content;
 
+    private UserDto.Feed user;
+
     @Builder
-    public CommentDto(String content) {
+    public CommentDto(String content, UserDto.Feed user) {
         this.content = content;
+        this.user = user;
     }
 }

--- a/src/main/java/com/zoooohs/instagramclone/domain/comment/entity/CommentEntity.java
+++ b/src/main/java/com/zoooohs/instagramclone/domain/comment/entity/CommentEntity.java
@@ -14,6 +14,11 @@ import javax.persistence.*;
 @Setter
 @NoArgsConstructor
 @Entity
+@NamedEntityGraphs({
+        @NamedEntityGraph(name = "comment-user", attributeNodes = {
+                @NamedAttributeNode(value = "user"),
+        }),
+})
 public class CommentEntity extends BaseEntity {
     @Column(name = "content")
     private String content;

--- a/src/main/java/com/zoooohs/instagramclone/domain/comment/entity/CommentEntity.java
+++ b/src/main/java/com/zoooohs/instagramclone/domain/comment/entity/CommentEntity.java
@@ -13,7 +13,7 @@ import javax.persistence.*;
 @Getter
 @Setter
 @NoArgsConstructor
-@Entity
+@Entity(name = "comment")
 @NamedEntityGraphs({
         @NamedEntityGraph(name = "comment-user", attributeNodes = {
                 @NamedAttributeNode(value = "user"),

--- a/src/main/java/com/zoooohs/instagramclone/domain/comment/entity/CommentEntity.java
+++ b/src/main/java/com/zoooohs/instagramclone/domain/comment/entity/CommentEntity.java
@@ -1,0 +1,28 @@
+package com.zoooohs.instagramclone.domain.comment.entity;
+
+import com.zoooohs.instagramclone.domain.common.entity.BaseEntity;
+import com.zoooohs.instagramclone.domain.post.entity.PostEntity;
+import com.zoooohs.instagramclone.domain.user.entity.UserEntity;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import lombok.Setter;
+
+import javax.persistence.*;
+
+
+@Getter
+@Setter
+@NoArgsConstructor
+@Entity
+public class CommentEntity extends BaseEntity {
+    @Column(name = "content")
+    private String content;
+
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "post_id", nullable = false)
+    private PostEntity post;
+
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "user_id", nullable = false)
+    private UserEntity user;
+}

--- a/src/main/java/com/zoooohs/instagramclone/domain/comment/repository/CommentRepository.java
+++ b/src/main/java/com/zoooohs/instagramclone/domain/comment/repository/CommentRepository.java
@@ -12,4 +12,6 @@ import java.util.List;
 public interface CommentRepository extends JpaRepository<CommentEntity, Long> {
     @EntityGraph("comment-user")
     List<CommentEntity> findByPostId(Long postId, Pageable pageable);
+
+    CommentEntity findByIdAndUserId(Long commentId, Long userId);
 }

--- a/src/main/java/com/zoooohs/instagramclone/domain/comment/repository/CommentRepository.java
+++ b/src/main/java/com/zoooohs/instagramclone/domain/comment/repository/CommentRepository.java
@@ -1,9 +1,15 @@
 package com.zoooohs.instagramclone.domain.comment.repository;
 
 import com.zoooohs.instagramclone.domain.comment.entity.CommentEntity;
+import org.springframework.data.domain.Pageable;
+import org.springframework.data.jpa.repository.EntityGraph;
 import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.stereotype.Repository;
 
+import java.util.List;
+
 @Repository
 public interface CommentRepository extends JpaRepository<CommentEntity, Long> {
+    @EntityGraph("comment-user")
+    List<CommentEntity> findByPostId(Long postId, Pageable pageable);
 }

--- a/src/main/java/com/zoooohs/instagramclone/domain/comment/repository/CommentRepository.java
+++ b/src/main/java/com/zoooohs/instagramclone/domain/comment/repository/CommentRepository.java
@@ -1,0 +1,9 @@
+package com.zoooohs.instagramclone.domain.comment.repository;
+
+import com.zoooohs.instagramclone.domain.comment.entity.CommentEntity;
+import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.stereotype.Repository;
+
+@Repository
+public interface CommentRepository extends JpaRepository<CommentEntity, Long> {
+}

--- a/src/main/java/com/zoooohs/instagramclone/domain/comment/service/CommentService.java
+++ b/src/main/java/com/zoooohs/instagramclone/domain/comment/service/CommentService.java
@@ -1,8 +1,13 @@
 package com.zoooohs.instagramclone.domain.comment.service;
 
 import com.zoooohs.instagramclone.domain.comment.dto.CommentDto;
+import com.zoooohs.instagramclone.domain.common.model.PageModel;
 import com.zoooohs.instagramclone.domain.user.dto.UserDto;
+
+import java.util.List;
 
 public interface CommentService {
     CommentDto create(CommentDto commentDto, Long postId, UserDto userDto);
+
+    List<CommentDto> getPostCommentList(Long postId, PageModel pageModel);
 }

--- a/src/main/java/com/zoooohs/instagramclone/domain/comment/service/CommentService.java
+++ b/src/main/java/com/zoooohs/instagramclone/domain/comment/service/CommentService.java
@@ -12,4 +12,6 @@ public interface CommentService {
     List<CommentDto> getPostCommentList(Long postId, PageModel pageModel);
 
     CommentDto updateComment(Long commentId, CommentDto commentDto, UserDto userDto);
+
+    Long deleteById(Long commentId, UserDto userDto);
 }

--- a/src/main/java/com/zoooohs/instagramclone/domain/comment/service/CommentService.java
+++ b/src/main/java/com/zoooohs/instagramclone/domain/comment/service/CommentService.java
@@ -1,0 +1,8 @@
+package com.zoooohs.instagramclone.domain.comment.service;
+
+import com.zoooohs.instagramclone.domain.comment.dto.CommentDto;
+import com.zoooohs.instagramclone.domain.user.dto.UserDto;
+
+public interface CommentService {
+    CommentDto create(CommentDto commentDto, Long postId, UserDto userDto);
+}

--- a/src/main/java/com/zoooohs/instagramclone/domain/comment/service/CommentService.java
+++ b/src/main/java/com/zoooohs/instagramclone/domain/comment/service/CommentService.java
@@ -10,4 +10,6 @@ public interface CommentService {
     CommentDto create(CommentDto commentDto, Long postId, UserDto userDto);
 
     List<CommentDto> getPostCommentList(Long postId, PageModel pageModel);
+
+    CommentDto updateComment(Long commentId, CommentDto commentDto, UserDto userDto);
 }

--- a/src/main/java/com/zoooohs/instagramclone/domain/comment/service/CommentServiceImpl.java
+++ b/src/main/java/com/zoooohs/instagramclone/domain/comment/service/CommentServiceImpl.java
@@ -56,4 +56,14 @@ public class CommentServiceImpl implements CommentService {
         comment = this.commentRepository.save(comment);
         return this.modelMapper.map(comment, CommentDto.class);
     }
+
+    @Override
+    public Long deleteById(Long commentId, UserDto userDto) {
+        CommentEntity comment = this.commentRepository.findByIdAndUserId(commentId, userDto.getId());
+        if (comment == null) {
+            throw new ZooooException(ErrorCode.COMMENT_NOT_FOUND);
+        }
+        this.commentRepository.delete(comment);
+        return commentId;
+    }
 }

--- a/src/main/java/com/zoooohs/instagramclone/domain/comment/service/CommentServiceImpl.java
+++ b/src/main/java/com/zoooohs/instagramclone/domain/comment/service/CommentServiceImpl.java
@@ -45,4 +45,15 @@ public class CommentServiceImpl implements CommentService {
         List<CommentEntity> comments = this.commentRepository.findByPostId(post.getId(), PageRequest.of(pageModel.getIndex(), pageModel.getSize()));
         return comments.stream().map(entity -> this.modelMapper.map(entity, CommentDto.class)).collect(Collectors.toList());
     }
+
+    @Override
+    public CommentDto updateComment(Long commentId, CommentDto commentDto, UserDto userDto) {
+        CommentEntity comment = this.commentRepository.findByIdAndUserId(commentId, userDto.getId());
+        if (comment == null) {
+            throw new ZooooException(ErrorCode.COMMENT_NOT_FOUND);
+        }
+        comment.setContent(commentDto.getContent());
+        comment = this.commentRepository.save(comment);
+        return this.modelMapper.map(comment, CommentDto.class);
+    }
 }

--- a/src/main/java/com/zoooohs/instagramclone/domain/comment/service/CommentServiceImpl.java
+++ b/src/main/java/com/zoooohs/instagramclone/domain/comment/service/CommentServiceImpl.java
@@ -3,6 +3,7 @@ package com.zoooohs.instagramclone.domain.comment.service;
 import com.zoooohs.instagramclone.domain.comment.dto.CommentDto;
 import com.zoooohs.instagramclone.domain.comment.entity.CommentEntity;
 import com.zoooohs.instagramclone.domain.comment.repository.CommentRepository;
+import com.zoooohs.instagramclone.domain.common.model.PageModel;
 import com.zoooohs.instagramclone.domain.post.entity.PostEntity;
 import com.zoooohs.instagramclone.domain.post.repository.PostRepository;
 import com.zoooohs.instagramclone.domain.user.dto.UserDto;
@@ -11,9 +12,12 @@ import com.zoooohs.instagramclone.exception.ErrorCode;
 import com.zoooohs.instagramclone.exception.ZooooException;
 import lombok.RequiredArgsConstructor;
 import org.modelmapper.ModelMapper;
+import org.springframework.data.domain.PageRequest;
 import org.springframework.stereotype.Service;
 
 import javax.transaction.Transactional;
+import java.util.List;
+import java.util.stream.Collectors;
 
 @RequiredArgsConstructor
 @Service
@@ -33,5 +37,12 @@ public class CommentServiceImpl implements CommentService {
         comment.setUser(user);
         comment = this.commentRepository.save(comment);
         return this.modelMapper.map(comment, CommentDto.class);
+    }
+
+    @Override
+    public List<CommentDto> getPostCommentList(Long postId, PageModel pageModel) {
+        PostEntity post = this.postRepository.findById(postId).orElseThrow(() -> new ZooooException(ErrorCode.POST_NOT_FOUND));
+        List<CommentEntity> comments = this.commentRepository.findByPostId(post.getId(), PageRequest.of(pageModel.getIndex(), pageModel.getSize()));
+        return comments.stream().map(entity -> this.modelMapper.map(entity, CommentDto.class)).collect(Collectors.toList());
     }
 }

--- a/src/main/java/com/zoooohs/instagramclone/domain/comment/service/CommentServiceImpl.java
+++ b/src/main/java/com/zoooohs/instagramclone/domain/comment/service/CommentServiceImpl.java
@@ -1,0 +1,37 @@
+package com.zoooohs.instagramclone.domain.comment.service;
+
+import com.zoooohs.instagramclone.domain.comment.dto.CommentDto;
+import com.zoooohs.instagramclone.domain.comment.entity.CommentEntity;
+import com.zoooohs.instagramclone.domain.comment.repository.CommentRepository;
+import com.zoooohs.instagramclone.domain.post.entity.PostEntity;
+import com.zoooohs.instagramclone.domain.post.repository.PostRepository;
+import com.zoooohs.instagramclone.domain.user.dto.UserDto;
+import com.zoooohs.instagramclone.domain.user.entity.UserEntity;
+import com.zoooohs.instagramclone.exception.ErrorCode;
+import com.zoooohs.instagramclone.exception.ZooooException;
+import lombok.RequiredArgsConstructor;
+import org.modelmapper.ModelMapper;
+import org.springframework.stereotype.Service;
+
+import javax.transaction.Transactional;
+
+@RequiredArgsConstructor
+@Service
+public class CommentServiceImpl implements CommentService {
+
+    private final ModelMapper modelMapper;
+    private final CommentRepository commentRepository;
+    private final PostRepository postRepository;
+
+    @Transactional
+    @Override
+    public CommentDto create(CommentDto commentDto, Long postId, UserDto userDto) {
+        UserEntity user = UserEntity.builder().id(userDto.getId()).build();
+        PostEntity post = this.postRepository.findById(postId).orElseThrow(() -> new ZooooException(ErrorCode.POST_NOT_FOUND));
+        CommentEntity comment = this.modelMapper.map(commentDto, CommentEntity.class);
+        comment.setPost(post);
+        comment.setUser(user);
+        comment = this.commentRepository.save(comment);
+        return this.modelMapper.map(comment, CommentDto.class);
+    }
+}

--- a/src/main/java/com/zoooohs/instagramclone/domain/post/entity/PostEntity.java
+++ b/src/main/java/com/zoooohs/instagramclone/domain/post/entity/PostEntity.java
@@ -45,7 +45,8 @@ public class PostEntity extends BaseEntity {
     }
 
     @Builder
-    public PostEntity(String description, UserEntity user) {
+    public PostEntity(Long id, String description, UserEntity user) {
+        this.id = id;
         this.description = description;
         this.user = user;
         this.photos = new ArrayList<>();

--- a/src/main/java/com/zoooohs/instagramclone/domain/user/dto/UserDto.java
+++ b/src/main/java/com/zoooohs/instagramclone/domain/user/dto/UserDto.java
@@ -20,9 +20,16 @@ public class UserDto {
     }
 
     @Data
+    @NoArgsConstructor
     public static class Feed {
         private Long id;
         private String name;
+
+        @Builder
+        public Feed(Long id, String name) {
+            this.id = id;
+            this.name = name;
+        }
     }
 
     @Data

--- a/src/main/java/com/zoooohs/instagramclone/domain/user/entity/UserEntity.java
+++ b/src/main/java/com/zoooohs/instagramclone/domain/user/entity/UserEntity.java
@@ -46,7 +46,8 @@ public class UserEntity extends BaseEntity implements UserDetails {
     private PhotoEntity profilePhoto;
 
     @Builder
-    public UserEntity(String email, String password, String name) {
+    public UserEntity(Long id, String email, String password, String name) {
+        this.id = id;
         this.email = email;
         this.password = password;
         this.name = name;

--- a/src/main/java/com/zoooohs/instagramclone/exception/ErrorCode.java
+++ b/src/main/java/com/zoooohs/instagramclone/exception/ErrorCode.java
@@ -12,6 +12,7 @@ public enum ErrorCode {
     LOGIN_WRONG_INFO(HttpStatus.NOT_FOUND, "사용자 정보를 찾을 수 없습니다."),
     USER_NOT_FOUND(HttpStatus.NOT_FOUND, "유저를 찾을 수 없습니다."),
     POST_NOT_FOUND(HttpStatus.NOT_FOUND, "게시글을 찾을 수 없습니다."),
+    COMMENT_NOT_FOUND(HttpStatus.NOT_FOUND, "댓글을 찾을 수 없습니다."),
 
     // 409 CONFLICT
     SIGN_UP_DUPLICATED_EMAIL_OR_NAME(HttpStatus.CONFLICT, "중복 된 email 혹은 name 입니다."),

--- a/src/test/java/com/zoooohs/instagramclone/domain/comment/controller/CommentControllerTest.java
+++ b/src/test/java/com/zoooohs/instagramclone/domain/comment/controller/CommentControllerTest.java
@@ -1,0 +1,74 @@
+package com.zoooohs.instagramclone.domain.comment.controller;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.zoooohs.instagramclone.configuration.SecurityConfiguration;
+import com.zoooohs.instagramclone.configure.WithAuthUser;
+import com.zoooohs.instagramclone.domain.comment.dto.CommentDto;
+import com.zoooohs.instagramclone.domain.comment.service.CommentService;
+import com.zoooohs.instagramclone.domain.user.dto.UserDto;
+import org.hamcrest.Matchers;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.junit.jupiter.MockitoExtension;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.autoconfigure.web.servlet.AutoConfigureMockMvc;
+import org.springframework.boot.test.autoconfigure.web.servlet.WebMvcTest;
+import org.springframework.boot.test.mock.mockito.MockBean;
+import org.springframework.context.annotation.ComponentScan;
+import org.springframework.context.annotation.FilterType;
+import org.springframework.http.MediaType;
+import org.springframework.test.web.servlet.MockMvc;
+import org.springframework.test.web.servlet.request.MockMvcRequestBuilders;
+import org.springframework.test.web.servlet.result.MockMvcResultMatchers;
+
+import static org.mockito.BDDMockito.*;
+
+
+@AutoConfigureMockMvc(addFilters = false)
+@WebMvcTest(
+        controllers = CommentController.class,
+        excludeFilters = {
+                @ComponentScan.Filter(
+                        type = FilterType.ASSIGNABLE_TYPE,
+                        classes = SecurityConfiguration.class
+                )
+        }
+)
+@ExtendWith(MockitoExtension.class)
+public class CommentControllerTest {
+    @Autowired
+    MockMvc mockMvc;
+
+    ObjectMapper objectMapper;
+
+    @MockBean
+    CommentService commentService;
+
+    @BeforeEach
+    public void setUp() {
+        objectMapper = new ObjectMapper();
+    }
+
+
+    @DisplayName("POST /post/{postId}/comment body, jwt 입력 받아, comment json return")
+    @Test
+    @WithAuthUser(email = "user1@test.test", id = 1L)
+    public void isOkTest() throws Exception {
+        Long postId = 1L;
+        String content = "comment content";
+        String url = String.format("/post/%d/comment", postId);
+        CommentDto commentDto = CommentDto.builder().content(content).build();
+        commentDto.setId(1L);
+
+        given(this.commentService.create(any(CommentDto.class), anyLong(), any(UserDto.class))).willReturn(commentDto);
+
+        mockMvc.perform(MockMvcRequestBuilders.post(url)
+                .contentType(MediaType.APPLICATION_JSON_VALUE)
+                .content(objectMapper.writeValueAsBytes(commentDto)))
+                .andExpect(MockMvcResultMatchers.status().isOk())
+                .andExpect(MockMvcResultMatchers.jsonPath("$.id", Matchers.instanceOf(Integer.class)))
+                .andExpect(MockMvcResultMatchers.jsonPath("$.content", Matchers.is(content)));
+    }
+}

--- a/src/test/java/com/zoooohs/instagramclone/domain/comment/controller/CommentControllerTest.java
+++ b/src/test/java/com/zoooohs/instagramclone/domain/comment/controller/CommentControllerTest.java
@@ -23,6 +23,7 @@ import org.springframework.context.annotation.ComponentScan;
 import org.springframework.context.annotation.FilterType;
 import org.springframework.http.MediaType;
 import org.springframework.test.web.servlet.MockMvc;
+import org.springframework.test.web.servlet.result.MockMvcResultMatchers;
 
 import java.util.ArrayList;
 
@@ -129,6 +130,24 @@ public class CommentControllerTest {
 
         mockMvc.perform(patch(url404).contentType(MediaType.APPLICATION_JSON_VALUE)
                         .content(objectMapper.writeValueAsBytes(commentDto)))
+                .andExpect(status().isNotFound());
+    }
+
+    @DisplayName("DELETE /comment/{commentId}, jwt 입력 받아, 댓글 삭제후 댓글 id 담긴 json 반환. 없는 댓글의 경우 404 반환")
+    @Test
+    @WithAuthUser(email = "user1@test.test", id = 1L)
+    public void deleteByIdTest() throws Exception {
+        String url = String.format("/comment/%d", 1L);
+        String url404 = String.format("/comment/%d", 2L);
+
+        given(this.commentService.deleteById(eq(1L), any(UserDto.class))).willReturn(1L);
+        given(this.commentService.deleteById(eq(2L), any(UserDto.class))).willThrow(new ZooooException(ErrorCode.COMMENT_NOT_FOUND));
+
+        mockMvc.perform(delete(url))
+                .andExpect(status().isOk())
+                .andExpect(MockMvcResultMatchers.content().string("1"));
+
+        mockMvc.perform(delete(url404))
                 .andExpect(status().isNotFound());
     }
 }

--- a/src/test/java/com/zoooohs/instagramclone/domain/comment/repository/CommentRepositoryTest.java
+++ b/src/test/java/com/zoooohs/instagramclone/domain/comment/repository/CommentRepositoryTest.java
@@ -93,4 +93,22 @@ public class CommentRepositoryTest {
         assertNotEquals(null, actual);
         assertEquals(pageSize, actual.size());
     }
+
+    @DisplayName("commentRepository.findByIdAndUserId commentId, userId 받아와서 해당 유저의 댓글 가져오는 기능 테스트")
+    @Test
+    public void findByIdAndUserIdTest() {
+        CommentEntity comment = new CommentEntity();
+        comment.setContent("content22");
+        comment.setUser(user);
+        comment.setPost(post);
+        comment = this.commentRepository.save(comment);
+
+        CommentEntity actual = this.commentRepository.findByIdAndUserId(comment.getId(), user.getId());
+        CommentEntity actualNull = this.commentRepository.findByIdAndUserId(comment.getId(), user.getId()+3L);
+
+        assertNotNull(comment);
+        assertEquals(comment.getId(), actual.getId());
+        assertEquals(comment.getContent(), actual.getContent());
+        assertNull(actualNull);
+    }
 }

--- a/src/test/java/com/zoooohs/instagramclone/domain/comment/repository/CommentRepositoryTest.java
+++ b/src/test/java/com/zoooohs/instagramclone/domain/comment/repository/CommentRepositoryTest.java
@@ -111,4 +111,20 @@ public class CommentRepositoryTest {
         assertEquals(comment.getContent(), actual.getContent());
         assertNull(actualNull);
     }
+
+    @DisplayName("comment Repository delete(commentEntity)로 댓글 삭제 테스트")
+    @Test
+    public void deleteTest() {
+        CommentEntity comment = new CommentEntity();
+        comment.setContent("content22");
+        comment.setUser(user);
+        comment.setPost(post);
+        comment = this.commentRepository.save(comment);
+
+        Long commentId = comment.getId();
+
+        this.commentRepository.delete(comment);
+
+        assertThrows(Exception.class, () -> commentRepository.findById(commentId).orElseThrow(() -> new Exception()));
+    }
 }

--- a/src/test/java/com/zoooohs/instagramclone/domain/comment/repository/CommentRepositoryTest.java
+++ b/src/test/java/com/zoooohs/instagramclone/domain/comment/repository/CommentRepositoryTest.java
@@ -1,0 +1,66 @@
+package com.zoooohs.instagramclone.domain.comment.repository;
+
+import com.zoooohs.instagramclone.domain.comment.entity.CommentEntity;
+import com.zoooohs.instagramclone.domain.post.entity.PostEntity;
+import com.zoooohs.instagramclone.domain.post.repository.PostRepository;
+import com.zoooohs.instagramclone.domain.user.entity.UserEntity;
+import com.zoooohs.instagramclone.domain.user.repository.UserRepository;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.autoconfigure.jdbc.AutoConfigureTestDatabase;
+import org.springframework.boot.test.autoconfigure.orm.jpa.DataJpaTest;
+import org.springframework.data.jpa.repository.config.EnableJpaAuditing;
+import org.springframework.security.crypto.factory.PasswordEncoderFactories;
+import org.springframework.security.crypto.password.PasswordEncoder;
+
+import java.util.Date;
+
+import static org.junit.jupiter.api.Assertions.*;
+
+@EnableJpaAuditing
+@DataJpaTest
+@AutoConfigureTestDatabase(replace = AutoConfigureTestDatabase.Replace.NONE)
+public class CommentRepositoryTest {
+
+    @Autowired
+    CommentRepository commentRepository;
+
+    @Autowired
+    UserRepository userRepository;
+
+    @Autowired
+    PostRepository postRepository;
+
+    private PasswordEncoder passwordEncoder;
+
+
+    @DisplayName("comment save 테스트")
+    @Test
+    public void saveTest() {
+        UserEntity user;
+        passwordEncoder = PasswordEncoderFactories.createDelegatingPasswordEncoder();
+        Date now = new Date();
+        String testEmail = "tt-sign-up-test-id"+now.getTime()+"@email.com";
+        String testPassword = "passwd";
+        String testName = "sign-up-test-name"+now.getTime();
+        user = new UserEntity();
+        user.setEmail(testEmail);
+        user.setPassword(passwordEncoder.encode(testPassword));
+        user.setName(testName);
+        user = this.userRepository.save(user);
+        PostEntity post = PostEntity.builder().description("post1").user(user).build();
+        post = this.postRepository.save(post);
+
+
+        CommentEntity comment = new CommentEntity();
+        comment.setContent("content");
+        comment.setUser(user);
+        comment.setPost(post);
+
+        CommentEntity actual = this.commentRepository.save(comment);
+
+        assertEquals(comment.getContent(), actual.getContent());
+        assertTrue(actual.getId() != null);
+    }
+}

--- a/src/test/java/com/zoooohs/instagramclone/domain/comment/repository/CommentRepositoryTest.java
+++ b/src/test/java/com/zoooohs/instagramclone/domain/comment/repository/CommentRepositoryTest.java
@@ -5,16 +5,21 @@ import com.zoooohs.instagramclone.domain.post.entity.PostEntity;
 import com.zoooohs.instagramclone.domain.post.repository.PostRepository;
 import com.zoooohs.instagramclone.domain.user.entity.UserEntity;
 import com.zoooohs.instagramclone.domain.user.repository.UserRepository;
+import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.autoconfigure.jdbc.AutoConfigureTestDatabase;
 import org.springframework.boot.test.autoconfigure.orm.jpa.DataJpaTest;
+import org.springframework.data.domain.PageRequest;
+import org.springframework.data.domain.Pageable;
 import org.springframework.data.jpa.repository.config.EnableJpaAuditing;
 import org.springframework.security.crypto.factory.PasswordEncoderFactories;
 import org.springframework.security.crypto.password.PasswordEncoder;
 
+import java.util.ArrayList;
 import java.util.Date;
+import java.util.List;
 
 import static org.junit.jupiter.api.Assertions.*;
 
@@ -33,12 +38,12 @@ public class CommentRepositoryTest {
     PostRepository postRepository;
 
     private PasswordEncoder passwordEncoder;
+    private PostEntity post;
+    private UserEntity user;
 
 
-    @DisplayName("comment save 테스트")
-    @Test
-    public void saveTest() {
-        UserEntity user;
+    @BeforeEach
+    public void setUp() {
         passwordEncoder = PasswordEncoderFactories.createDelegatingPasswordEncoder();
         Date now = new Date();
         String testEmail = "tt-sign-up-test-id"+now.getTime()+"@email.com";
@@ -49,10 +54,13 @@ public class CommentRepositoryTest {
         user.setPassword(passwordEncoder.encode(testPassword));
         user.setName(testName);
         user = this.userRepository.save(user);
-        PostEntity post = PostEntity.builder().description("post1").user(user).build();
+        post = PostEntity.builder().description("post1").user(user).build();
         post = this.postRepository.save(post);
+    }
 
-
+    @DisplayName("comment save 테스트")
+    @Test
+    public void saveTest() {
         CommentEntity comment = new CommentEntity();
         comment.setContent("content");
         comment.setUser(user);
@@ -62,5 +70,27 @@ public class CommentRepositoryTest {
 
         assertEquals(comment.getContent(), actual.getContent());
         assertTrue(actual.getId() != null);
+    }
+
+    @DisplayName("comment repository findByPostId, postId로 comment list 받아오기 테스트")
+    @Test
+    public void findByPostIdTest() {
+        List<CommentEntity> testList = new ArrayList<>();
+        for (int i = 0; i < 30; i++) {
+            CommentEntity comment = new CommentEntity();
+            comment.setContent("content");
+            comment.setUser(user);
+            comment.setPost(post);
+            testList.add(comment);
+        }
+        this.commentRepository.saveAll(testList);
+
+        int pageSize = 20;
+        Pageable pageable = PageRequest.of(0, pageSize);
+
+        List<CommentEntity> actual = this.commentRepository.findByPostId(post.getId(), pageable);
+
+        assertNotEquals(null, actual);
+        assertEquals(pageSize, actual.size());
     }
 }

--- a/src/test/java/com/zoooohs/instagramclone/domain/comment/service/CommentServiceTest.java
+++ b/src/test/java/com/zoooohs/instagramclone/domain/comment/service/CommentServiceTest.java
@@ -3,6 +3,7 @@ package com.zoooohs.instagramclone.domain.comment.service;
 import com.zoooohs.instagramclone.domain.comment.dto.CommentDto;
 import com.zoooohs.instagramclone.domain.comment.entity.CommentEntity;
 import com.zoooohs.instagramclone.domain.comment.repository.CommentRepository;
+import com.zoooohs.instagramclone.domain.common.model.PageModel;
 import com.zoooohs.instagramclone.domain.post.entity.PostEntity;
 import com.zoooohs.instagramclone.domain.post.repository.PostRepository;
 import com.zoooohs.instagramclone.domain.user.dto.UserDto;
@@ -17,6 +18,7 @@ import org.mockito.Spy;
 import org.mockito.junit.jupiter.MockitoExtension;
 import org.modelmapper.ModelMapper;
 
+import java.util.List;
 import java.util.Optional;
 
 import static org.junit.jupiter.api.Assertions.*;
@@ -36,6 +38,8 @@ public class CommentServiceTest {
     private UserDto userDto;
     private Long postId;
     private CommentDto commentDto;
+    private PostEntity post;
+    private PageModel pageModel;
 
     @BeforeEach
     public void setUp() {
@@ -44,6 +48,9 @@ public class CommentServiceTest {
         userDto = UserDto.builder().id(1L).build();
         postId = 1L;
         commentDto = CommentDto.builder().content("content").build();
+        post = PostEntity.builder().id(postId).build();
+
+        pageModel = PageModel.builder().index(0).size(20).build();
     }
 
 
@@ -54,7 +61,6 @@ public class CommentServiceTest {
         comment.setId(1L);
         comment.setContent(commentDto.getContent());
 
-        PostEntity post = PostEntity.builder().id(1L).build();
 
         given(this.postRepository.findById(eq(postId))).willReturn(Optional.ofNullable(post));
         given(this.postRepository.findById(eq(2L))).willReturn(Optional.ofNullable(null));
@@ -74,4 +80,35 @@ public class CommentServiceTest {
             fail();
         }
     }
+
+    @DisplayName("Long postId 받아 comment list반환하는 service 테스트")
+    @Test
+    public void getPostCommentListTest() {
+        Long postId = 1L;
+
+        given(this.postRepository.findById(postId)).willReturn(Optional.ofNullable(post));
+
+        List<CommentDto> actual = this.commentService.getPostCommentList(postId, pageModel);
+
+        assertNotEquals(null, actual);
+        assertTrue(actual.size() <= pageModel.getSize());
+    }
+
+    @DisplayName("없는 postId의 경우 POST_NOT_FOUND Exception throw 하는 service테스트")
+    @Test
+    public void getPostCommentList404FailureTest() {
+        Long postId = 1L;
+
+        given(this.postRepository.findById(postId)).willReturn(Optional.ofNullable(null));
+
+        try {
+            this.commentService.getPostCommentList(postId, pageModel);
+            fail();
+        } catch (ZooooException e) {
+            assertEquals(ErrorCode.POST_NOT_FOUND, e.getErrorCode());
+        } catch (Exception e) {
+            fail();
+        }
+    }
+
 }

--- a/src/test/java/com/zoooohs/instagramclone/domain/comment/service/CommentServiceTest.java
+++ b/src/test/java/com/zoooohs/instagramclone/domain/comment/service/CommentServiceTest.java
@@ -1,0 +1,77 @@
+package com.zoooohs.instagramclone.domain.comment.service;
+
+import com.zoooohs.instagramclone.domain.comment.dto.CommentDto;
+import com.zoooohs.instagramclone.domain.comment.entity.CommentEntity;
+import com.zoooohs.instagramclone.domain.comment.repository.CommentRepository;
+import com.zoooohs.instagramclone.domain.post.entity.PostEntity;
+import com.zoooohs.instagramclone.domain.post.repository.PostRepository;
+import com.zoooohs.instagramclone.domain.user.dto.UserDto;
+import com.zoooohs.instagramclone.exception.ErrorCode;
+import com.zoooohs.instagramclone.exception.ZooooException;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.Mock;
+import org.mockito.Spy;
+import org.mockito.junit.jupiter.MockitoExtension;
+import org.modelmapper.ModelMapper;
+
+import java.util.Optional;
+
+import static org.junit.jupiter.api.Assertions.*;
+import static org.mockito.BDDMockito.*;
+
+@ExtendWith(MockitoExtension.class)
+public class CommentServiceTest {
+
+    CommentService commentService;
+
+    @Spy
+    ModelMapper modelMapper;
+    @Mock
+    CommentRepository commentRepository;
+    @Mock
+    PostRepository postRepository;
+    private UserDto userDto;
+    private Long postId;
+    private CommentDto commentDto;
+
+    @BeforeEach
+    public void setUp() {
+        commentService = new CommentServiceImpl(modelMapper, commentRepository, postRepository);
+
+        userDto = UserDto.builder().id(1L).build();
+        postId = 1L;
+        commentDto = CommentDto.builder().content("content").build();
+    }
+
+
+    @DisplayName("commentBody, user, postId 입력받아 comment id 포함된 comment Body 반환, db에 저장, postId가 없는 post일 경우 404, POST_NOT_FOUND")
+    @Test
+    public void createTest() {
+        CommentEntity comment = new CommentEntity();
+        comment.setId(1L);
+        comment.setContent(commentDto.getContent());
+
+        PostEntity post = PostEntity.builder().id(1L).build();
+
+        given(this.postRepository.findById(eq(postId))).willReturn(Optional.ofNullable(post));
+        given(this.postRepository.findById(eq(2L))).willReturn(Optional.ofNullable(null));
+        given(this.commentRepository.save(any(CommentEntity.class))).willReturn(comment);
+
+        CommentDto actual = commentService.create(commentDto, postId, userDto);
+
+        assertTrue(actual.getId() != null);
+        assertEquals(commentDto.getContent(), actual.getContent());
+
+        try {
+            commentService.create(commentDto, 2L, userDto);
+            fail();
+        } catch (ZooooException e) {
+            assertEquals(ErrorCode.POST_NOT_FOUND, e.getErrorCode());
+        } catch (Exception e) {
+            fail();
+        }
+    }
+}

--- a/src/test/java/com/zoooohs/instagramclone/domain/comment/service/CommentServiceTest.java
+++ b/src/test/java/com/zoooohs/instagramclone/domain/comment/service/CommentServiceTest.java
@@ -120,7 +120,7 @@ public class CommentServiceTest {
         newComment.setId(commentEntity.getId());
         newComment.setContent(newContent);
         given(commentRepository.findByIdAndUserId(eq(commentEntity.getId()), eq(userDto.getId()))).willReturn(commentEntity);
-        given(commentRepository.save(newComment)).willReturn(newComment);
+        given(commentRepository.save(any(CommentEntity.class))).willReturn(newComment);
 
         CommentDto actual = commentService.updateComment(commentEntity.getId(), commentDto, userDto);
 
@@ -141,5 +141,31 @@ public class CommentServiceTest {
             fail();
         }
     }
+
+    @DisplayName("comment Id, userDto 입력 받아 comment 지우는 서비스 메소드 테스트")
+    @Test
+    public void deleteByIdTest() {
+        Long commentId = 1L;
+        given(commentRepository.findByIdAndUserId(eq(1L), eq(userDto.getId()))).willReturn(commentEntity);
+        Long actual = commentService.deleteById(commentId, userDto);
+
+        assertEquals(commentId, actual);
+    }
+
+    @DisplayName("comment Id, userDto 입력 받아 comment 지우는 서비스 메소드에서 comment 없으면 COMMENT_NOT_FOUND 예외 쓰로우 테스트")
+    @Test
+    public void deleteByIdFailure404Test() {
+        Long commentId = 1L;
+        given(commentRepository.findByIdAndUserId(eq(1L), eq(userDto.getId()))).willReturn(null);
+        try {
+            commentService.deleteById(commentId, userDto);
+            fail();
+        } catch (ZooooException e) {
+            assertEquals(ErrorCode.COMMENT_NOT_FOUND, e.getErrorCode());
+        } catch (Exception e) {
+            fail();
+        }
+    }
+
 
 }


### PR DESCRIPTION
- storage service 구현
    - multipartfile 여러개 받아서 storage에 저장하는 서비스 구현
        - 저장하는 기능의 interface를 만들어 테스트
        - filesystem에 먼저 적용하여 기능 작동 확인 후 AWS S3 연동
    - 게시글 작성시 multipartfile 함께 올리도록 변경
        - multipartfile이 입력으로 들어가게 될 경우 request body를 사용할 수 없고, 다른 데이터 또한 multipart로 전달해야 했음
- 댓글 기능 구현
    - 댓글 CRUD API 구현
    - 현재는 게시글의 댓글만 적용된 상태
        - 추후 다른 기능 구현 후, 대댓글 기능 구현 예상
- bug fix
    - [link](https://dogfooter219.notion.site/bug-fix-auth-500-227f577fa284439296158e777e772e5d)