### PR TITLE
1.0.0

### DIFF
--- a/README.md
+++ b/README.md
@@ -55,6 +55,7 @@ TDD 공부도 하고 Spring 프로젝트를 계속 손에 익혀본다.
         ```
 
 ## 변경사항 및 TODO
+- [2022/02/21 (1.0.0 릴리즈)](https://dogfooter219.notion.site/1-0-0-e4307c1f5b1c4b5baf0d9754dc442284)
 - [2022/02/12](https://dogfooter219.notion.site/2022-02-3-3c0bd58d436a462b94880dcf3a366e33)
 - [2022/02/08](https://dogfooter219.notion.site/2022-02-2-b66133f5680a4094bba04662b2975ad8)
 - [2022/02/01](https://dogfooter219.notion.site/2022-02-1-7ebcb5300811407da8f3bd8dc6c13490)

--- a/README.md
+++ b/README.md
@@ -5,16 +5,32 @@ TDD 공부도 하고 Spring 프로젝트를 계속 손에 익혀본다.
 
 ## 시작하기 앞서
 - 환경 변수 추가
-  - DB_URL
-    - DB 연결 URL
-  - DB_PORT
-    - DB 연결 PORT
-  - DB_USE
-    - database 이름
-  - DB_ID
-    - database 사용자 ID
-  - DB_PASSWORD
-    - database 사용자 PASSWORD
+  - 필수 입력
+    - ACCESS_TOKEN_KEY
+      - access token 발급용 secret key
+      - 임의 값 입력
+    - REFRESH_TOKEN_KEY
+      - refresh token 발급용 secret key
+      - 임의 값 입력
+    - DB_URL
+      - DB 연결 URL
+    - DB_PORT
+      - DB 연결 PORT
+    - DB_USE
+      - database 이름
+    - DB_ID
+      - database 사용자 ID
+    - DB_PASSWORD
+      - database 사용자 PASSWORD
+  - 선택 입력
+    - ACCESS_TOKEN_VALID_TIME
+      - access token 만료 시간
+      - millisecond 단위
+      - 기본 값 1일
+    - REFRESH_TOKEN_VALID_TIME
+      - refresh token 만료 시간
+      - millisecond 단위
+      - 기본 값 5일
 - 파일 추가 및 변경
     - resources/application-aws.yaml
         ```yaml

--- a/build.gradle
+++ b/build.gradle
@@ -5,7 +5,7 @@ plugins {
 }
 
 group = 'com.zoooohs'
-version = '0.0.1-SNAPSHOT'
+version = '0.0.1'
 sourceCompatibility = '11'
 
 configurations {
@@ -35,6 +35,8 @@ dependencies {
 	testImplementation 'org.springframework.boot:spring-boot-starter-test'
 	testImplementation group: 'org.mockito', name: 'mockito-inline', version: '4.0.0'
 	testImplementation 'io.findify:s3mock_2.13:0.2.6'
+	implementation 'org.springdoc:springdoc-openapi-ui:1.6.6'
+	implementation 'org.springdoc:springdoc-openapi-security:1.6.6'
 }
 
 test {

--- a/build.gradle
+++ b/build.gradle
@@ -5,7 +5,7 @@ plugins {
 }
 
 group = 'com.zoooohs'
-version = '0.0.1'
+version = '1.0.0'
 sourceCompatibility = '11'
 
 configurations {

--- a/src/main/java/com/zoooohs/instagramclone/configuration/ExceptionHandlerConfiguration.java
+++ b/src/main/java/com/zoooohs/instagramclone/configuration/ExceptionHandlerConfiguration.java
@@ -7,8 +7,9 @@ import org.springframework.http.HttpHeaders;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.MethodArgumentNotValidException;
-import org.springframework.web.bind.annotation.ControllerAdvice;
 import org.springframework.web.bind.annotation.ExceptionHandler;
+import org.springframework.web.bind.annotation.ResponseStatus;
+import org.springframework.web.bind.annotation.RestControllerAdvice;
 import org.springframework.web.context.request.WebRequest;
 import org.springframework.web.servlet.mvc.method.annotation.ResponseEntityExceptionHandler;
 
@@ -17,7 +18,7 @@ import java.io.IOException;
 import java.util.List;
 import java.util.stream.Collectors;
 
-@ControllerAdvice
+@RestControllerAdvice
 public class ExceptionHandlerConfiguration extends ResponseEntityExceptionHandler {
     @ExceptionHandler(ZooooException.class)
     public ResponseEntity<ZooooExceptionResponse> zooooExceptionHandler(HttpServletRequest request, final ZooooException e) {
@@ -50,6 +51,7 @@ public class ExceptionHandlerConfiguration extends ResponseEntityExceptionHandle
             Exception.class,
             IOException.class
     })
+    @ResponseStatus(HttpStatus.INTERNAL_SERVER_ERROR)
     public ResponseEntity<ZooooExceptionResponse> exceptionHandler(HttpServletRequest request, final Exception e) {
         // TODO: AOP로 로깅하기
         e.printStackTrace();

--- a/src/main/java/com/zoooohs/instagramclone/configuration/OpenAPIConfiguration.java
+++ b/src/main/java/com/zoooohs/instagramclone/configuration/OpenAPIConfiguration.java
@@ -1,0 +1,31 @@
+package com.zoooohs.instagramclone.configuration;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+import io.swagger.v3.core.jackson.ModelResolver;
+import io.swagger.v3.oas.models.Components;
+import io.swagger.v3.oas.models.OpenAPI;
+import io.swagger.v3.oas.models.info.Contact;
+import io.swagger.v3.oas.models.info.Info;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.context.annotation.Bean;
+import org.springframework.stereotype.Component;
+
+@Component
+public class OpenAPIConfiguration {
+
+    @Bean
+    public ModelResolver modelResolver(ObjectMapper objectMapper) {
+        return new ModelResolver(objectMapper);
+    }
+
+    @Bean
+    public OpenAPI openAPI(@Value("${instagram-clone.version}") String version) {
+        Info info = new Info().title("Instagram Clone Backend").version(version)
+                .description("퇴근하고 뭐라도 해보려고 한다. TDD 공부도 하고 Spring 프로젝트를 계속 손에 익혀본다.")
+                .contact(new Contact().name("zoooo-hs (Hyunsu Ju)").url("https://github.com/zoooo-hs").email("dogfooter219@gmail.com"));
+
+        return new OpenAPI()
+                .components(new Components())
+                .info(info);
+    }
+}

--- a/src/main/java/com/zoooohs/instagramclone/configuration/SecurityConfiguration.java
+++ b/src/main/java/com/zoooohs/instagramclone/configuration/SecurityConfiguration.java
@@ -4,7 +4,6 @@ import com.zoooohs.instagramclone.filter.JwtAuthenticationFilter;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.context.annotation.Bean;
-import org.springframework.context.annotation.Configuration;
 import org.springframework.security.authentication.AuthenticationManager;
 import org.springframework.security.config.annotation.web.builders.HttpSecurity;
 import org.springframework.security.config.annotation.web.configuration.EnableWebSecurity;
@@ -49,6 +48,10 @@ public class SecurityConfiguration extends WebSecurityConfigurerAdapter {
                 .and()
                 .authorizeRequests()
                 .antMatchers("/auth/**").permitAll()
+                .antMatchers("/v3/api-docs/**").permitAll()
+                .antMatchers("/swagger-ui/**").permitAll()
+                .antMatchers("/swagger-resources/**").permitAll()
+                .antMatchers("/configuration/**").permitAll()
                 .anyRequest().authenticated()
                 .and()
                 .addFilterBefore(new JwtAuthenticationFilter(jwtTokenProvider), UsernamePasswordAuthenticationFilter.class);

--- a/src/main/java/com/zoooohs/instagramclone/domain/auth/controller/AuthController.java
+++ b/src/main/java/com/zoooohs/instagramclone/domain/auth/controller/AuthController.java
@@ -3,6 +3,12 @@ package com.zoooohs.instagramclone.domain.auth.controller;
 import com.zoooohs.instagramclone.domain.auth.dto.AuthDto;
 import com.zoooohs.instagramclone.domain.common.model.SearchModel;
 import com.zoooohs.instagramclone.domain.auth.service.AuthService;
+import com.zoooohs.instagramclone.exception.ZooooExceptionResponse;
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.media.Content;
+import io.swagger.v3.oas.annotations.media.Schema;
+import io.swagger.v3.oas.annotations.responses.ApiResponse;
+import io.swagger.v3.oas.annotations.responses.ApiResponses;
 import lombok.RequiredArgsConstructor;
 import org.springframework.web.bind.annotation.*;
 
@@ -14,28 +20,75 @@ import javax.validation.Valid;
 public class AuthController {
     private final AuthService authService;
 
+    @Operation(summary = "회원 가입", description = "email, name, password 를 입력 받아 새로운 회원 생성")
+    @ApiResponses(value = {
+            @ApiResponse(
+                    responseCode = "200", description = "회원 가입 완료 및 토큰 발급",
+                    content = { @Content(mediaType = "application/json", schema = @Schema(implementation = AuthDto.Token.class)) }
+            ),
+            @ApiResponse(
+                    responseCode = "409", description = "email 혹은 name 중복",
+                    content = { @Content(mediaType = "application/json", schema = @Schema(implementation = ZooooExceptionResponse.class)) }
+            ),
+    })
     @PostMapping("/auth/sign-up")
     public AuthDto.Token signUp(@RequestBody @Valid AuthDto.SignUp signUp) {
         return this.authService.signUp(signUp);
     }
 
+    @Operation(summary = "로그인", description = "email, password 입력 받아 로그인")
+    @ApiResponses(value = {
+            @ApiResponse(
+                    responseCode = "200", description = "로그인 완료 및 토큰 발급",
+                    content = { @Content(mediaType = "application/json", schema = @Schema(implementation = AuthDto.Token.class)) }
+            ),
+            @ApiResponse(
+                    responseCode = "404", description = "로그인 정보 오류",
+                    content = { @Content(mediaType = "application/json", schema = @Schema(implementation = ZooooExceptionResponse.class)) }
+            ),
+    })
     @PostMapping("/auth/sign-in")
     public AuthDto.Token signIn(@RequestBody @Valid AuthDto.SignIn signIn) {
         return this.authService.signIn(signIn);
     }
 
+    @Operation(summary = "토큰 재발급", description = "유효한 refresh token 으로 새로운 jwt 발급")
+    @ApiResponses(value = {
+            @ApiResponse(
+                    responseCode = "200", description = "토큰 재발급 완료",
+                    content = { @Content(mediaType = "application/json", schema = @Schema(implementation = AuthDto.Token.class)) }
+            ),
+            @ApiResponse(
+                    responseCode = "401", description = "토큰 만료",
+                    content = { @Content(mediaType = "application/json", schema = @Schema(implementation = ZooooExceptionResponse.class)) }
+            ),
+    })
     @PostMapping("/auth/refresh")
     public AuthDto.Token refresh(@RequestBody @Valid AuthDto.Token token) {
         return this.authService.refresh(token);
     }
 
+    @Operation(summary = "name 중복 찾기", description = "회원 가입 시 name 중복 확인 용 api")
+    @ApiResponses(value = {
+            @ApiResponse(
+                    responseCode = "200", description = "중복 유무 반환",
+                    content = { @Content(mediaType = "application/json", schema = @Schema(implementation = Boolean.class)) }
+            ),
+    })
     @GetMapping("/auth/name")
-    public Boolean checkName(@ModelAttribute SearchModel searchModel) {
-        return this.authService.checkDuplicatedName(searchModel.getKeyword());
+    public Boolean checkName(@RequestParam("keyword") String name) {
+        return this.authService.checkDuplicatedName(name);
     }
 
+    @Operation(summary = "email 중복 찾기", description = "회원 가입 시 email 중복 확인 용 api")
+    @ApiResponses(value = {
+            @ApiResponse(
+                    responseCode = "200", description = "중복 유무 반환",
+                    content = { @Content(mediaType = "application/json", schema = @Schema(implementation = Boolean.class)) }
+            ),
+    })
     @GetMapping("/auth/email")
-    public Boolean checkEmail(@ModelAttribute SearchModel searchModel) {
-        return this.authService.checkDuplicatedEmail(searchModel.getKeyword());
+    public Boolean checkEmail(@RequestParam("keyword") String email) {
+        return this.authService.checkDuplicatedEmail(email);
     }
 }

--- a/src/main/java/com/zoooohs/instagramclone/domain/auth/dto/AuthDto.java
+++ b/src/main/java/com/zoooohs/instagramclone/domain/auth/dto/AuthDto.java
@@ -1,6 +1,7 @@
 package com.zoooohs.instagramclone.domain.auth.dto;
 
 import com.zoooohs.instagramclone.util.Patterns;
+import io.swagger.v3.oas.annotations.media.Schema;
 import lombok.*;
 
 import javax.validation.constraints.Email;
@@ -10,6 +11,7 @@ import javax.validation.constraints.Size;
 
 public class AuthDto {
 
+    @Schema(name = "AuthDto.SignUp")
     @Data
     @NoArgsConstructor
     public static class SignUp {
@@ -31,6 +33,7 @@ public class AuthDto {
         }
     }
 
+    @Schema(name = "AuthDto.SignIn")
     @Data
     @NoArgsConstructor
     public static class SignIn {
@@ -47,6 +50,7 @@ public class AuthDto {
         }
     }
 
+    @Schema(name = "AuthDto.Token")
     @Getter
     @Setter
     @NoArgsConstructor

--- a/src/main/java/com/zoooohs/instagramclone/domain/comment/controller/CommentController.java
+++ b/src/main/java/com/zoooohs/instagramclone/domain/comment/controller/CommentController.java
@@ -24,8 +24,8 @@ public class CommentController {
     }
 
     @GetMapping("/post/{postId}/comment")
-    public List<CommentDto> getPostCommentList(@PathVariable Long postId, @ModelAttribute @NotNull PageModel pageModel) {
-        return commentService.getPostCommentList(postId, pageModel);
+    public List<CommentDto> getPostCommentList(@PathVariable Long postId, @ModelAttribute @NotNull PageModel pageModel, @AuthenticationPrincipal UserDto userDto) {
+        return commentService.getPostCommentList(postId, pageModel, userDto.getId());
     }
 
     @PatchMapping("/comment/{commentId}")

--- a/src/main/java/com/zoooohs/instagramclone/domain/comment/controller/CommentController.java
+++ b/src/main/java/com/zoooohs/instagramclone/domain/comment/controller/CommentController.java
@@ -4,6 +4,13 @@ import com.zoooohs.instagramclone.domain.comment.dto.CommentDto;
 import com.zoooohs.instagramclone.domain.comment.service.CommentService;
 import com.zoooohs.instagramclone.domain.common.model.PageModel;
 import com.zoooohs.instagramclone.domain.user.dto.UserDto;
+import com.zoooohs.instagramclone.exception.ZooooExceptionResponse;
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.media.ArraySchema;
+import io.swagger.v3.oas.annotations.media.Content;
+import io.swagger.v3.oas.annotations.media.Schema;
+import io.swagger.v3.oas.annotations.responses.ApiResponse;
+import io.swagger.v3.oas.annotations.responses.ApiResponses;
 import lombok.RequiredArgsConstructor;
 import org.springframework.security.core.annotation.AuthenticationPrincipal;
 import org.springframework.web.bind.annotation.*;
@@ -18,25 +25,68 @@ public class CommentController {
 
     private final CommentService commentService;
 
+    @Operation(summary = "게시글 댓글 작성", description = "게시글 댓글을 작성한다.")
+    @ApiResponses(value = {
+            @ApiResponse(
+                    responseCode = "200", description = "게시글 댓글 작성 성공. 작성 결과 반환",
+                    content = { @Content(mediaType = "application/json", schema = @Schema(implementation = CommentDto.class)) }
+            ),
+            @ApiResponse(
+                    responseCode = "404", description = "게시글이 존재하지 않음",
+                    content = { @Content(mediaType = "application/json", schema = @Schema(implementation = ZooooExceptionResponse.class)) }
+            ),
+    })
     @PostMapping("/post/{postId}/comment")
     public CommentDto create(@RequestBody @Valid CommentDto commentDto, @PathVariable Long postId, @AuthenticationPrincipal UserDto userDto) {
         return commentService.create(commentDto, postId, userDto);
     }
 
+    @Operation(summary = "게시글 댓글 조회", description = "게시글 댓글을 리스트를 불러온다.")
+    @ApiResponses(value = {
+            @ApiResponse(
+                    responseCode = "200", description = "조회 성공. 댓글 리스트 반환",
+                    content = { @Content(mediaType = "application/json", array = @ArraySchema(schema = @Schema(implementation = CommentDto.class))) }
+            ),
+            @ApiResponse(
+                    responseCode = "404", description = "게시글이 존재하지 않음",
+                    content = { @Content(mediaType = "application/json", schema = @Schema(implementation = ZooooExceptionResponse.class)) }
+            ),
+    })
     @GetMapping("/post/{postId}/comment")
     public List<CommentDto> getPostCommentList(@PathVariable Long postId, @ModelAttribute @NotNull PageModel pageModel, @AuthenticationPrincipal UserDto userDto) {
         return commentService.getPostCommentList(postId, pageModel, userDto.getId());
     }
 
+    @Operation(summary = "게시글 댓글 수정", description = "게시글 댓글의 내용을 수정한다.")
+    @ApiResponses(value = {
+            @ApiResponse(
+                    responseCode = "200", description = "수정 성공. 수정 결과 반환",
+                    content = { @Content(mediaType = "application/json", schema = @Schema(implementation = CommentDto.class)) }
+            ),
+            @ApiResponse(
+                    responseCode = "404", description = "댓글이 존재하지 않음",
+                    content = { @Content(mediaType = "application/json", schema = @Schema(implementation = ZooooExceptionResponse.class)) }
+            ),
+    })
     @PatchMapping("/comment/{commentId}")
     public CommentDto updateComment(@PathVariable Long commentId, @RequestBody CommentDto commentDto, @AuthenticationPrincipal UserDto userDto) {
         return commentService.updateComment(commentId, commentDto, userDto);
     }
 
+    @Operation(summary = "게시글 댓글 삭제", description = "게시글 댓글을 삭제한다.")
+    @ApiResponses(value = {
+            @ApiResponse(
+                    responseCode = "200", description = "삭제 성공. 삭제된 댓글 ID 반환",
+                    content = { @Content(mediaType = "application/json", schema = @Schema(implementation = Long.class)) }
+            ),
+            @ApiResponse(
+                    responseCode = "404", description = "댓글이 존재하지 않음",
+                    content = { @Content(mediaType = "application/json", schema = @Schema(implementation = ZooooExceptionResponse.class)) }
+            ),
+    })
     @DeleteMapping("/comment/{commentId}")
     public Long deleteById(@PathVariable Long commentId, @AuthenticationPrincipal UserDto userDto) {
-        Long re =  commentService.deleteById(commentId, userDto);
-        return re;
+        return commentService.deleteById(commentId, userDto);
     }
 
 }

--- a/src/main/java/com/zoooohs/instagramclone/domain/comment/dto/CommentDto.java
+++ b/src/main/java/com/zoooohs/instagramclone/domain/comment/dto/CommentDto.java
@@ -1,6 +1,7 @@
 package com.zoooohs.instagramclone.domain.comment.dto;
 
 import com.zoooohs.instagramclone.domain.user.dto.UserDto;
+import io.swagger.v3.oas.annotations.media.Schema;
 import lombok.Builder;
 import lombok.Data;
 import lombok.NoArgsConstructor;
@@ -12,13 +13,19 @@ import javax.validation.constraints.NotNull;
 @NoArgsConstructor
 public class CommentDto {
     private Long id;
+
+    @Schema(description = "댓글 내용")
     @NotNull
     private String content;
 
+    @Schema(description = "댓글 작성자")
     private UserDto.Feed user;
 
+    @Schema(description = "받은 좋아요 개수")
     private Long likeCount;
+
     @Accessors(fluent = true)
+    @Schema(name = "liked", description = "내가 좋아요를 눌렀는지 여부")
     private Boolean isLiked;
 
 

--- a/src/main/java/com/zoooohs/instagramclone/domain/comment/dto/CommentDto.java
+++ b/src/main/java/com/zoooohs/instagramclone/domain/comment/dto/CommentDto.java
@@ -4,6 +4,7 @@ import com.zoooohs.instagramclone.domain.user.dto.UserDto;
 import lombok.Builder;
 import lombok.Data;
 import lombok.NoArgsConstructor;
+import lombok.experimental.Accessors;
 
 import javax.validation.constraints.NotNull;
 
@@ -16,9 +17,17 @@ public class CommentDto {
 
     private UserDto.Feed user;
 
+    private Long likeCount;
+    @Accessors(fluent = true)
+    private Boolean isLiked;
+
+
     @Builder
-    public CommentDto(String content, UserDto.Feed user) {
+    public CommentDto(Long id, String content, UserDto.Feed user, Long likeCount, Boolean isLiked) {
+        this.id = id;
         this.content = content;
         this.user = user;
+        this.likeCount = likeCount;
+        this.isLiked = isLiked;
     }
 }

--- a/src/main/java/com/zoooohs/instagramclone/domain/comment/entity/CommentEntity.java
+++ b/src/main/java/com/zoooohs/instagramclone/domain/comment/entity/CommentEntity.java
@@ -1,6 +1,7 @@
 package com.zoooohs.instagramclone.domain.comment.entity;
 
 import com.zoooohs.instagramclone.domain.common.entity.BaseEntity;
+import com.zoooohs.instagramclone.domain.like.entity.CommentLikeEntity;
 import com.zoooohs.instagramclone.domain.post.entity.PostEntity;
 import com.zoooohs.instagramclone.domain.user.entity.UserEntity;
 import lombok.Builder;
@@ -9,6 +10,8 @@ import lombok.NoArgsConstructor;
 import lombok.Setter;
 
 import javax.persistence.*;
+import java.util.HashSet;
+import java.util.Set;
 
 
 @Getter
@@ -18,6 +21,7 @@ import javax.persistence.*;
 @NamedEntityGraphs({
         @NamedEntityGraph(name = "comment-user", attributeNodes = {
                 @NamedAttributeNode(value = "user"),
+                @NamedAttributeNode(value = "likes"),
         }),
 })
 public class CommentEntity extends BaseEntity {
@@ -31,6 +35,13 @@ public class CommentEntity extends BaseEntity {
     @ManyToOne(fetch = FetchType.LAZY)
     @JoinColumn(name = "user_id", nullable = false)
     private UserEntity user;
+
+    @OneToMany(mappedBy = "comment", fetch = FetchType.LAZY)
+    private Set<CommentLikeEntity> likes = new HashSet<>();
+
+    public Long getLikeCount() {
+        return (long) likes.size();
+    }
 
     @Builder
     public CommentEntity(String content, PostEntity post, UserEntity user) {

--- a/src/main/java/com/zoooohs/instagramclone/domain/comment/service/CommentService.java
+++ b/src/main/java/com/zoooohs/instagramclone/domain/comment/service/CommentService.java
@@ -9,7 +9,7 @@ import java.util.List;
 public interface CommentService {
     CommentDto create(CommentDto commentDto, Long postId, UserDto userDto);
 
-    List<CommentDto> getPostCommentList(Long postId, PageModel pageModel);
+    List<CommentDto> getPostCommentList(Long postId, PageModel pageModel, Long userId);
 
     CommentDto updateComment(Long commentId, CommentDto commentDto, UserDto userDto);
 

--- a/src/main/java/com/zoooohs/instagramclone/domain/comment/service/CommentServiceImpl.java
+++ b/src/main/java/com/zoooohs/instagramclone/domain/comment/service/CommentServiceImpl.java
@@ -16,7 +16,7 @@ import org.modelmapper.ModelMapper;
 import org.springframework.data.domain.PageRequest;
 import org.springframework.stereotype.Service;
 
-import javax.transaction.Transactional;
+import org.springframework.transaction.annotation.Transactional;
 import java.util.List;
 import java.util.stream.Collectors;
 
@@ -53,6 +53,7 @@ public class CommentServiceImpl implements CommentService {
         }).collect(Collectors.toList());
     }
 
+    @Transactional
     @Override
     public CommentDto updateComment(Long commentId, CommentDto commentDto, UserDto userDto) {
         CommentEntity comment = this.commentRepository.findByIdAndUserId(commentId, userDto.getId());
@@ -64,6 +65,7 @@ public class CommentServiceImpl implements CommentService {
         return this.modelMapper.map(comment, CommentDto.class);
     }
 
+    @Transactional
     @Override
     public Long deleteById(Long commentId, UserDto userDto) {
         CommentEntity comment = this.commentRepository.findByIdAndUserId(commentId, userDto.getId());

--- a/src/main/java/com/zoooohs/instagramclone/domain/common/model/PageModel.java
+++ b/src/main/java/com/zoooohs/instagramclone/domain/common/model/PageModel.java
@@ -5,9 +5,13 @@ import lombok.*;
 @Getter
 @Setter
 @NoArgsConstructor
-@AllArgsConstructor
-@Builder
 public class PageModel {
-    private int index;
-    private int size;
+    protected int index;
+    protected int size;
+
+    @Builder
+    public PageModel(int index, int size) {
+        this.index = index;
+        this.size = size;
+    }
 }

--- a/src/main/java/com/zoooohs/instagramclone/domain/common/model/PageModel.java
+++ b/src/main/java/com/zoooohs/instagramclone/domain/common/model/PageModel.java
@@ -1,12 +1,15 @@
 package com.zoooohs.instagramclone.domain.common.model;
 
+import io.swagger.v3.oas.annotations.media.Schema;
 import lombok.*;
 
 @Getter
 @Setter
 @NoArgsConstructor
 public class PageModel {
+    @Schema(description = "페이지 번호")
     protected int index;
+    @Schema(description = "페이지 당 로우 개수")
     protected int size;
 
     @Builder

--- a/src/main/java/com/zoooohs/instagramclone/domain/common/model/SearchModel.java
+++ b/src/main/java/com/zoooohs/instagramclone/domain/common/model/SearchModel.java
@@ -5,11 +5,14 @@ import lombok.Getter;
 import lombok.NoArgsConstructor;
 import lombok.Setter;
 
+import javax.validation.constraints.NotNull;
+
 @Getter
 @Setter
 @NoArgsConstructor
 public class SearchModel extends PageModel {
     private String keyword;
+    @NotNull
     private SearchKeyType searchKey;
 
     public SearchModel(int index, int size, String keyword, SearchKeyType searchKey) {

--- a/src/main/java/com/zoooohs/instagramclone/domain/common/model/SearchModel.java
+++ b/src/main/java/com/zoooohs/instagramclone/domain/common/model/SearchModel.java
@@ -1,6 +1,7 @@
 package com.zoooohs.instagramclone.domain.common.model;
 
 import com.zoooohs.instagramclone.domain.common.type.SearchKeyType;
+import io.swagger.v3.oas.annotations.media.Schema;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
 import lombok.Setter;
@@ -11,8 +12,10 @@ import javax.validation.constraints.NotNull;
 @Setter
 @NoArgsConstructor
 public class SearchModel extends PageModel {
+    @Schema(description = "검색 키워드")
     private String keyword;
     @NotNull
+    @Schema(name = "searchKey", description = "검색 종류. (이름, 해쉬 태그, ...)")
     private SearchKeyType searchKey;
 
     public SearchModel(int index, int size, String keyword, SearchKeyType searchKey) {

--- a/src/main/java/com/zoooohs/instagramclone/domain/common/model/SearchModel.java
+++ b/src/main/java/com/zoooohs/instagramclone/domain/common/model/SearchModel.java
@@ -5,14 +5,11 @@ import lombok.Getter;
 import lombok.NoArgsConstructor;
 import lombok.Setter;
 
-import javax.validation.constraints.NotNull;
-
 @Getter
 @Setter
 @NoArgsConstructor
 public class SearchModel extends PageModel {
     private String keyword;
-    @NotNull
     private SearchKeyType searchKey;
 
     public SearchModel(int index, int size, String keyword, SearchKeyType searchKey) {

--- a/src/main/java/com/zoooohs/instagramclone/domain/common/model/SearchModel.java
+++ b/src/main/java/com/zoooohs/instagramclone/domain/common/model/SearchModel.java
@@ -1,12 +1,23 @@
 package com.zoooohs.instagramclone.domain.common.model;
 
+import com.zoooohs.instagramclone.domain.common.type.SearchKeyType;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
 import lombok.Setter;
 
+import javax.validation.constraints.NotNull;
+
 @Getter
 @Setter
 @NoArgsConstructor
-public class SearchModel {
+public class SearchModel extends PageModel {
     private String keyword;
+    @NotNull
+    private SearchKeyType searchKey;
+
+    public SearchModel(int index, int size, String keyword, SearchKeyType searchKey) {
+        super(index, size);
+        this.keyword = keyword;
+        this.searchKey = searchKey;
+    }
 }

--- a/src/main/java/com/zoooohs/instagramclone/domain/common/type/SearchKeyType.java
+++ b/src/main/java/com/zoooohs/instagramclone/domain/common/type/SearchKeyType.java
@@ -1,0 +1,5 @@
+package com.zoooohs.instagramclone.domain.common.type;
+
+public enum SearchKeyType {
+    NAME;
+}

--- a/src/main/java/com/zoooohs/instagramclone/domain/common/type/SearchKeyType.java
+++ b/src/main/java/com/zoooohs/instagramclone/domain/common/type/SearchKeyType.java
@@ -1,5 +1,5 @@
 package com.zoooohs.instagramclone.domain.common.type;
 
 public enum SearchKeyType {
-    NAME;
+    NAME, HASH_TAG;
 }

--- a/src/main/java/com/zoooohs/instagramclone/domain/file/controller/FileController.java
+++ b/src/main/java/com/zoooohs/instagramclone/domain/file/controller/FileController.java
@@ -3,8 +3,11 @@ package com.zoooohs.instagramclone.domain.file.controller;
 import com.zoooohs.instagramclone.domain.file.service.StorageService;
 import com.zoooohs.instagramclone.domain.photo.dto.PhotoDto;
 import com.zoooohs.instagramclone.domain.photo.service.PhotoService;
+import io.swagger.v3.oas.annotations.Operation;
 import org.springframework.beans.factory.annotation.Autowired;
-import org.springframework.web.bind.annotation.*;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestPart;
+import org.springframework.web.bind.annotation.RestController;
 import org.springframework.web.multipart.MultipartFile;
 
 import java.util.List;
@@ -18,6 +21,7 @@ public class FileController {
     @Autowired
     private PhotoService photoService;
 
+    @Operation(hidden = true)
     @PostMapping("/file")
     public List<PhotoDto.Photo> upload(@RequestPart List<MultipartFile> files) {
         List<String> paths = this.storageService.store(files);

--- a/src/main/java/com/zoooohs/instagramclone/domain/file/service/FileSystemStorageServiceImpl.java
+++ b/src/main/java/com/zoooohs/instagramclone/domain/file/service/FileSystemStorageServiceImpl.java
@@ -46,4 +46,11 @@ public class FileSystemStorageServiceImpl implements StorageService {
     public Boolean exists(String path) {
         return new File(path).exists();
     }
+
+    @Override
+    public void deleteAll(List<String> paths) {
+        for(String path: paths) {
+            this.delete(path);
+        }
+    }
 }

--- a/src/main/java/com/zoooohs/instagramclone/domain/file/service/FileSystemStorageServiceImpl.java
+++ b/src/main/java/com/zoooohs/instagramclone/domain/file/service/FileSystemStorageServiceImpl.java
@@ -2,14 +2,12 @@ package com.zoooohs.instagramclone.domain.file.service;
 
 import com.zoooohs.instagramclone.exception.ErrorCode;
 import com.zoooohs.instagramclone.exception.ZooooException;
-import com.zoooohs.instagramclone.util.FileUtils;
 import org.springframework.beans.factory.annotation.Value;
 import org.springframework.web.multipart.MultipartFile;
 
 import java.io.File;
 import java.io.IOException;
 import java.util.List;
-import java.util.UUID;
 import java.util.stream.Collectors;
 
 //@Service
@@ -21,7 +19,7 @@ public class FileSystemStorageServiceImpl implements StorageService {
     @Override
     public List<String> store(List<MultipartFile> files) {
         return files.stream().map(multipartFile -> {
-            String path = bucketName + UUID.randomUUID() + FileUtils.getExtension(multipartFile.getOriginalFilename());
+            String path = bucketName + multipartFile.getOriginalFilename();
             File file = new File(path);
             try {
                 multipartFile.transferTo(file);
@@ -35,5 +33,17 @@ public class FileSystemStorageServiceImpl implements StorageService {
 
     public void setBucketName(String bucketName) {
         this.bucketName = bucketName;
+    }
+
+    @Override
+    public void delete(String path) {
+        if (exists(path)) {
+            new File(path).delete();
+        }
+    }
+
+    @Override
+    public Boolean exists(String path) {
+        return new File(path).exists();
     }
 }

--- a/src/main/java/com/zoooohs/instagramclone/domain/file/service/FileSystemStorageServiceImpl.java
+++ b/src/main/java/com/zoooohs/instagramclone/domain/file/service/FileSystemStorageServiceImpl.java
@@ -13,7 +13,7 @@ import java.util.stream.Collectors;
 //@Service
 public class FileSystemStorageServiceImpl implements StorageService {
 
-    @Value("${storage.filesystem}")
+    @Value("${instagram-clone.storage.filesystem}")
     private String bucketName;
 
     @Override

--- a/src/main/java/com/zoooohs/instagramclone/domain/file/service/S3StorageServiceImpl.java
+++ b/src/main/java/com/zoooohs/instagramclone/domain/file/service/S3StorageServiceImpl.java
@@ -2,6 +2,7 @@ package com.zoooohs.instagramclone.domain.file.service;
 
 import com.amazonaws.services.s3.AmazonS3;
 import com.amazonaws.services.s3.model.CannedAccessControlList;
+import com.amazonaws.services.s3.model.DeleteObjectsRequest;
 import com.amazonaws.services.s3.model.ObjectMetadata;
 import com.amazonaws.services.s3.model.PutObjectRequest;
 import com.zoooohs.instagramclone.exception.ErrorCode;
@@ -12,8 +13,6 @@ import org.springframework.beans.factory.annotation.Value;
 import org.springframework.stereotype.Service;
 import org.springframework.web.multipart.MultipartFile;
 
-import javax.annotation.PostConstruct;
-import java.io.FileNotFoundException;
 import java.io.IOException;
 import java.io.InputStream;
 import java.util.List;
@@ -64,6 +63,20 @@ public class S3StorageServiceImpl implements StorageService {
         String fileName = getFileName(path);
         if (fileName == null) return false;
         return amazonS3Client.doesObjectExist(bucketName, fileName);
+    }
+
+    @Override
+    public void deleteAll(List<String> paths) {
+        DeleteObjectsRequest request = new DeleteObjectsRequest(bucketName);
+        List<DeleteObjectsRequest.KeyVersion> keys = paths.stream()
+                .map(this::getFileName).map(DeleteObjectsRequest.KeyVersion::new).collect(Collectors.toList());
+        request.setKeys(keys);
+        try {
+            amazonS3Client.deleteObjects(request);
+        } catch (Exception e) {
+            // TODO: AOP log
+            e.printStackTrace();
+        }
     }
 
     private String getFileName(String path) {

--- a/src/main/java/com/zoooohs/instagramclone/domain/file/service/S3StorageServiceImpl.java
+++ b/src/main/java/com/zoooohs/instagramclone/domain/file/service/S3StorageServiceImpl.java
@@ -12,6 +12,8 @@ import org.springframework.beans.factory.annotation.Value;
 import org.springframework.stereotype.Service;
 import org.springframework.web.multipart.MultipartFile;
 
+import javax.annotation.PostConstruct;
+import java.io.FileNotFoundException;
 import java.io.IOException;
 import java.io.InputStream;
 import java.util.List;
@@ -46,5 +48,33 @@ public class S3StorageServiceImpl implements StorageService {
 
     public void setBucketName(String bucketName) {
         this.bucketName = bucketName;
+    }
+
+    @Override
+    public void delete(String path) {
+        // 없는 파일 삭제 호출 시 내부 로그라도 남겨야 할 것 같음
+        if (exists(path)) {
+            String fileName = getFileName(path);
+            amazonS3Client.deleteObject(bucketName, fileName);
+        }
+    }
+
+    @Override
+    public Boolean exists(String path) {
+        String fileName = getFileName(path);
+        if (fileName == null) return false;
+        return amazonS3Client.doesObjectExist(bucketName, fileName);
+    }
+
+    private String getFileName(String path) {
+        String [] temp = path.split("amazonaws\\.com/");
+        if (temp.length != 2) {
+            temp = path.split(bucketName + "/");
+        }
+        if (temp.length != 2) {
+            return null;
+        }
+        String fileName= temp[1];
+        return fileName;
     }
 }

--- a/src/main/java/com/zoooohs/instagramclone/domain/file/service/StorageService.java
+++ b/src/main/java/com/zoooohs/instagramclone/domain/file/service/StorageService.java
@@ -12,4 +12,6 @@ public interface StorageService {
     void delete(String path);
 
     Boolean exists(String path);
+
+    void deleteAll(List<String> paths);
 }

--- a/src/main/java/com/zoooohs/instagramclone/domain/file/service/StorageService.java
+++ b/src/main/java/com/zoooohs/instagramclone/domain/file/service/StorageService.java
@@ -8,4 +8,8 @@ public interface StorageService {
     List<String> store(List<MultipartFile> files);
 
     void setBucketName(String bucketName);
+
+    void delete(String path);
+
+    Boolean exists(String path);
 }

--- a/src/main/java/com/zoooohs/instagramclone/domain/follow/controller/FollowController.java
+++ b/src/main/java/com/zoooohs/instagramclone/domain/follow/controller/FollowController.java
@@ -3,6 +3,12 @@ package com.zoooohs.instagramclone.domain.follow.controller;
 import com.zoooohs.instagramclone.domain.follow.dto.FollowDto;
 import com.zoooohs.instagramclone.domain.follow.service.FollowService;
 import com.zoooohs.instagramclone.domain.user.dto.UserDto;
+import com.zoooohs.instagramclone.exception.ZooooExceptionResponse;
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.media.Content;
+import io.swagger.v3.oas.annotations.media.Schema;
+import io.swagger.v3.oas.annotations.responses.ApiResponse;
+import io.swagger.v3.oas.annotations.responses.ApiResponses;
 import lombok.RequiredArgsConstructor;
 import org.springframework.security.core.annotation.AuthenticationPrincipal;
 import org.springframework.web.bind.annotation.DeleteMapping;
@@ -16,11 +22,45 @@ public class FollowController {
 
     private final FollowService followService;
 
+    @Operation(summary = "팔로우", description = "특정 유저를 팔로우 한다.")
+    @ApiResponses(value = {
+            @ApiResponse(
+                    responseCode = "200", description = "팔로우 성공. 팔로우 결과 반환",
+                    content = { @Content(mediaType = "application/json", schema = @Schema(implementation = FollowDto.class)) }
+            ),
+            @ApiResponse(
+                    responseCode = "404", description = "유저를 찾을 수 없음",
+                    content = { @Content(mediaType = "application/json", schema = @Schema(implementation = ZooooExceptionResponse.class)) }
+            ),
+            @ApiResponse(
+                    responseCode = "409", description = "자신을 팔로우",
+                    content = { @Content(mediaType = "application/json", schema = @Schema(implementation = ZooooExceptionResponse.class)) }
+            ),
+            @ApiResponse(
+                    responseCode = "409", description = "이미 팔로우하고 있음",
+                    content = { @Content(mediaType = "application/json", schema = @Schema(implementation = ZooooExceptionResponse.class)) }
+            ),
+    })
     @PostMapping("/user/{followUserId}/follow")
     public FollowDto follow(@PathVariable Long followUserId, @AuthenticationPrincipal UserDto userDto) {
         return followService.follow(followUserId, userDto.getId());
     }
 
+    @Operation(summary = "언팔로우", description = "특정 유저를 언팔로우 한다.")
+    @ApiResponses(value = {
+            @ApiResponse(
+                    responseCode = "200", description = "언팔로우 성공. 팔로우 ID 반환",
+                    content = { @Content(mediaType = "application/json", schema = @Schema(implementation = Long.class)) }
+            ),
+            @ApiResponse(
+                    responseCode = "404", description = "팔로우 정보를 찾을 수 없음",
+                    content = { @Content(mediaType = "application/json", schema = @Schema(implementation = ZooooExceptionResponse.class)) }
+            ),
+            @ApiResponse(
+                    responseCode = "409", description = "자신을 팔로우",
+                    content = { @Content(mediaType = "application/json", schema = @Schema(implementation = ZooooExceptionResponse.class)) }
+            ),
+    })
     @DeleteMapping("/user/{followUserId}/follow")
     public Long unfollow(@PathVariable Long followUserId, @AuthenticationPrincipal UserDto userDto) {
         return followService.unfollow(followUserId, userDto.getId());

--- a/src/main/java/com/zoooohs/instagramclone/domain/follow/controller/FollowController.java
+++ b/src/main/java/com/zoooohs/instagramclone/domain/follow/controller/FollowController.java
@@ -1,0 +1,22 @@
+package com.zoooohs.instagramclone.domain.follow.controller;
+
+import com.zoooohs.instagramclone.domain.follow.dto.FollowDto;
+import com.zoooohs.instagramclone.domain.follow.service.FollowService;
+import com.zoooohs.instagramclone.domain.user.dto.UserDto;
+import lombok.RequiredArgsConstructor;
+import org.springframework.security.core.annotation.AuthenticationPrincipal;
+import org.springframework.web.bind.annotation.PathVariable;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+@RestController
+@RequiredArgsConstructor
+public class FollowController {
+
+    private final FollowService followService;
+
+    @PostMapping("/user/{followUserId}/follow")
+    public FollowDto follow(@PathVariable Long followUserId, @AuthenticationPrincipal UserDto userDto) {
+        return followService.follow(followUserId, userDto.getId());
+    }
+}

--- a/src/main/java/com/zoooohs/instagramclone/domain/follow/controller/FollowController.java
+++ b/src/main/java/com/zoooohs/instagramclone/domain/follow/controller/FollowController.java
@@ -5,6 +5,7 @@ import com.zoooohs.instagramclone.domain.follow.service.FollowService;
 import com.zoooohs.instagramclone.domain.user.dto.UserDto;
 import lombok.RequiredArgsConstructor;
 import org.springframework.security.core.annotation.AuthenticationPrincipal;
+import org.springframework.web.bind.annotation.DeleteMapping;
 import org.springframework.web.bind.annotation.PathVariable;
 import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.RestController;
@@ -18,5 +19,10 @@ public class FollowController {
     @PostMapping("/user/{followUserId}/follow")
     public FollowDto follow(@PathVariable Long followUserId, @AuthenticationPrincipal UserDto userDto) {
         return followService.follow(followUserId, userDto.getId());
+    }
+
+    @DeleteMapping("/user/{followUserId}/follow")
+    public Long unfollow(@PathVariable Long followUserId, @AuthenticationPrincipal UserDto userDto) {
+        return followService.unfollow(followUserId, userDto.getId());
     }
 }

--- a/src/main/java/com/zoooohs/instagramclone/domain/follow/dto/FollowDto.java
+++ b/src/main/java/com/zoooohs/instagramclone/domain/follow/dto/FollowDto.java
@@ -1,6 +1,7 @@
 package com.zoooohs.instagramclone.domain.follow.dto;
 
 import com.zoooohs.instagramclone.domain.user.dto.UserDto;
+import io.swagger.v3.oas.annotations.media.Schema;
 import lombok.Builder;
 import lombok.Data;
 import lombok.NoArgsConstructor;
@@ -9,6 +10,8 @@ import lombok.NoArgsConstructor;
 @NoArgsConstructor
 public class FollowDto {
     private Long id;
+
+    @Schema(description = "팔로우한 유저")
     private UserDto.Info followUser;
 
     @Builder

--- a/src/main/java/com/zoooohs/instagramclone/domain/follow/dto/FollowDto.java
+++ b/src/main/java/com/zoooohs/instagramclone/domain/follow/dto/FollowDto.java
@@ -1,0 +1,19 @@
+package com.zoooohs.instagramclone.domain.follow.dto;
+
+import com.zoooohs.instagramclone.domain.user.dto.UserDto;
+import lombok.Builder;
+import lombok.Data;
+import lombok.NoArgsConstructor;
+
+@Data
+@NoArgsConstructor
+public class FollowDto {
+    private Long id;
+    private UserDto.Info followUser;
+
+    @Builder
+    public FollowDto(Long id, UserDto.Info follow) {
+        this.id = id;
+        this.followUser = follow;
+    }
+}

--- a/src/main/java/com/zoooohs/instagramclone/domain/follow/entity/FollowEntity.java
+++ b/src/main/java/com/zoooohs/instagramclone/domain/follow/entity/FollowEntity.java
@@ -1,0 +1,33 @@
+package com.zoooohs.instagramclone.domain.follow.entity;
+
+import com.zoooohs.instagramclone.domain.common.entity.BaseEntity;
+import com.zoooohs.instagramclone.domain.user.entity.UserEntity;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import lombok.Setter;
+
+import javax.persistence.Entity;
+import javax.persistence.FetchType;
+import javax.persistence.JoinColumn;
+import javax.persistence.ManyToOne;
+
+@Getter
+@Setter
+@NoArgsConstructor
+@Entity(name = "follow")
+public class FollowEntity extends BaseEntity {
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "follow_user_id", nullable = false)
+    private UserEntity followUser;
+
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "user_id", nullable = false)
+    private UserEntity user;
+
+    @Builder
+    public FollowEntity(UserEntity followUser, UserEntity user) {
+        this.followUser = followUser;
+        this.user = user;
+    }
+}

--- a/src/main/java/com/zoooohs/instagramclone/domain/follow/repository/FollowRepository.java
+++ b/src/main/java/com/zoooohs/instagramclone/domain/follow/repository/FollowRepository.java
@@ -4,7 +4,11 @@ import com.zoooohs.instagramclone.domain.follow.entity.FollowEntity;
 import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.stereotype.Repository;
 
+import java.util.List;
+
 @Repository
 public interface FollowRepository extends JpaRepository<FollowEntity, Long> {
     FollowEntity findByFollowUserIdAndUserId(Long followUserId, Long userId);
+
+    List<FollowEntity> findByUserId(Long userId);
 }

--- a/src/main/java/com/zoooohs/instagramclone/domain/follow/repository/FollowRepository.java
+++ b/src/main/java/com/zoooohs/instagramclone/domain/follow/repository/FollowRepository.java
@@ -1,0 +1,10 @@
+package com.zoooohs.instagramclone.domain.follow.repository;
+
+import com.zoooohs.instagramclone.domain.follow.entity.FollowEntity;
+import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.stereotype.Repository;
+
+@Repository
+public interface FollowRepository extends JpaRepository<FollowEntity, Long> {
+    FollowEntity findByFollowUserIdAndUserId(Long followUserId, Long userId);
+}

--- a/src/main/java/com/zoooohs/instagramclone/domain/follow/service/FollowService.java
+++ b/src/main/java/com/zoooohs/instagramclone/domain/follow/service/FollowService.java
@@ -4,4 +4,6 @@ import com.zoooohs.instagramclone.domain.follow.dto.FollowDto;
 
 public interface FollowService {
     FollowDto follow(Long followUserId, Long userId);
+
+    Long unfollow(Long followUserId, Long userId);
 }

--- a/src/main/java/com/zoooohs/instagramclone/domain/follow/service/FollowService.java
+++ b/src/main/java/com/zoooohs/instagramclone/domain/follow/service/FollowService.java
@@ -1,0 +1,7 @@
+package com.zoooohs.instagramclone.domain.follow.service;
+
+import com.zoooohs.instagramclone.domain.follow.dto.FollowDto;
+
+public interface FollowService {
+    FollowDto follow(Long followUserId, Long userId);
+}

--- a/src/main/java/com/zoooohs/instagramclone/domain/follow/service/FollowServiceImpl.java
+++ b/src/main/java/com/zoooohs/instagramclone/domain/follow/service/FollowServiceImpl.java
@@ -36,4 +36,18 @@ public class FollowServiceImpl implements FollowService {
         follow = followRepository.save(follow);
         return modelMapper.map(follow, FollowDto.class);
     }
+
+    @Override
+    public Long unfollow(Long followUserId, Long userId) {
+        if (followUserId.equals(userId)) {
+            throw new ZooooException(ErrorCode.FOLLOWING_SELF);
+        }
+        FollowEntity follow = followRepository.findByFollowUserIdAndUserId(followUserId, userId);
+        if (follow == null) {
+            throw new ZooooException(ErrorCode.FOLLOW_NOT_FOUND);
+        }
+        Long followId = follow.getId();
+        followRepository.delete(follow);
+        return followId;
+    }
 }

--- a/src/main/java/com/zoooohs/instagramclone/domain/follow/service/FollowServiceImpl.java
+++ b/src/main/java/com/zoooohs/instagramclone/domain/follow/service/FollowServiceImpl.java
@@ -11,6 +11,8 @@ import lombok.RequiredArgsConstructor;
 import org.modelmapper.ModelMapper;
 import org.springframework.stereotype.Service;
 
+import org.springframework.transaction.annotation.Transactional;
+
 @Service
 @RequiredArgsConstructor
 public class FollowServiceImpl implements FollowService {
@@ -19,6 +21,7 @@ public class FollowServiceImpl implements FollowService {
     private final UserRepository userRepository;
     private final ModelMapper modelMapper;
 
+    @Transactional
     @Override
     public FollowDto follow(Long followUserId, Long userId) {
         if (followUserId.equals(userId)) {
@@ -37,6 +40,7 @@ public class FollowServiceImpl implements FollowService {
         return modelMapper.map(follow, FollowDto.class);
     }
 
+    @Transactional
     @Override
     public Long unfollow(Long followUserId, Long userId) {
         if (followUserId.equals(userId)) {

--- a/src/main/java/com/zoooohs/instagramclone/domain/follow/service/FollowServiceImpl.java
+++ b/src/main/java/com/zoooohs/instagramclone/domain/follow/service/FollowServiceImpl.java
@@ -1,0 +1,39 @@
+package com.zoooohs.instagramclone.domain.follow.service;
+
+import com.zoooohs.instagramclone.domain.follow.dto.FollowDto;
+import com.zoooohs.instagramclone.domain.follow.entity.FollowEntity;
+import com.zoooohs.instagramclone.domain.follow.repository.FollowRepository;
+import com.zoooohs.instagramclone.domain.user.entity.UserEntity;
+import com.zoooohs.instagramclone.domain.user.repository.UserRepository;
+import com.zoooohs.instagramclone.exception.ErrorCode;
+import com.zoooohs.instagramclone.exception.ZooooException;
+import lombok.RequiredArgsConstructor;
+import org.modelmapper.ModelMapper;
+import org.springframework.stereotype.Service;
+
+@Service
+@RequiredArgsConstructor
+public class FollowServiceImpl implements FollowService {
+
+    private final FollowRepository followRepository;
+    private final UserRepository userRepository;
+    private final ModelMapper modelMapper;
+
+    @Override
+    public FollowDto follow(Long followUserId, Long userId) {
+        if (followUserId.equals(userId)) {
+            throw new ZooooException(ErrorCode.FOLLOWING_SELF);
+        }
+
+        UserEntity followUser = userRepository.findById(followUserId).orElseThrow(() -> new ZooooException(ErrorCode.USER_NOT_FOUND));
+        UserEntity user = UserEntity.builder().id(userId).build();
+
+        FollowEntity follow = followRepository.findByFollowUserIdAndUserId(followUserId, userId);
+        if (follow != null) {
+            throw new ZooooException(ErrorCode.ALREADY_FOLLOWED_USER);
+        }
+        follow = FollowEntity.builder().followUser(followUser).user(user).build();
+        follow = followRepository.save(follow);
+        return modelMapper.map(follow, FollowDto.class);
+    }
+}

--- a/src/main/java/com/zoooohs/instagramclone/domain/hashtag/controller/HashTagController.java
+++ b/src/main/java/com/zoooohs/instagramclone/domain/hashtag/controller/HashTagController.java
@@ -3,6 +3,12 @@ package com.zoooohs.instagramclone.domain.hashtag.controller;
 import com.zoooohs.instagramclone.domain.common.model.SearchModel;
 import com.zoooohs.instagramclone.domain.hashtag.dto.Search;
 import com.zoooohs.instagramclone.domain.hashtag.service.HashTagService;
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.media.ArraySchema;
+import io.swagger.v3.oas.annotations.media.Content;
+import io.swagger.v3.oas.annotations.media.Schema;
+import io.swagger.v3.oas.annotations.responses.ApiResponse;
+import io.swagger.v3.oas.annotations.responses.ApiResponses;
 import lombok.RequiredArgsConstructor;
 import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.ModelAttribute;
@@ -16,6 +22,13 @@ public class HashTagController {
 
     private final HashTagService hashTagService;
 
+    @Operation(summary = "해쉬 태그 검색", description = "비슷한 단어의 해쉬태그를 검색 한다.")
+    @ApiResponses(value = {
+            @ApiResponse(
+                    responseCode = "200", description = "검색 성공. 해쉬태그 리스트 반환",
+                    content = { @Content(mediaType = "application/json", array = @ArraySchema(schema = @Schema(implementation = Search.class))) }
+            ),
+    })
     @GetMapping("/hash-tag")
     public List<Search> search(@ModelAttribute SearchModel searchModel) {
         return hashTagService.search(searchModel);

--- a/src/main/java/com/zoooohs/instagramclone/domain/hashtag/controller/HashTagController.java
+++ b/src/main/java/com/zoooohs/instagramclone/domain/hashtag/controller/HashTagController.java
@@ -1,0 +1,23 @@
+package com.zoooohs.instagramclone.domain.hashtag.controller;
+
+import com.zoooohs.instagramclone.domain.common.model.SearchModel;
+import com.zoooohs.instagramclone.domain.hashtag.dto.Search;
+import com.zoooohs.instagramclone.domain.hashtag.service.HashTagService;
+import lombok.RequiredArgsConstructor;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.ModelAttribute;
+import org.springframework.web.bind.annotation.RestController;
+
+import java.util.List;
+
+@RestController
+@RequiredArgsConstructor
+public class HashTagController {
+
+    private final HashTagService hashTagService;
+
+    @GetMapping("/hash-tag")
+    public List<Search> search(@ModelAttribute SearchModel searchModel) {
+        return hashTagService.search(searchModel);
+    }
+}

--- a/src/main/java/com/zoooohs/instagramclone/domain/hashtag/dto/HashTagDto.java
+++ b/src/main/java/com/zoooohs/instagramclone/domain/hashtag/dto/HashTagDto.java
@@ -1,0 +1,20 @@
+package com.zoooohs.instagramclone.domain.hashtag.dto;
+
+import com.zoooohs.instagramclone.domain.post.dto.PostDto;
+import lombok.Builder;
+import lombok.Data;
+import lombok.NoArgsConstructor;
+
+@Data
+@NoArgsConstructor
+public class HashTagDto {
+    private Long id;
+    private PostDto.Post post;
+    private String tag;
+
+    @Builder
+    public HashTagDto(PostDto.Post post, String tag) {
+        this.post = post;
+        this.tag = tag;
+    }
+}

--- a/src/main/java/com/zoooohs/instagramclone/domain/hashtag/dto/Search.java
+++ b/src/main/java/com/zoooohs/instagramclone/domain/hashtag/dto/Search.java
@@ -1,0 +1,18 @@
+package com.zoooohs.instagramclone.domain.hashtag.dto;
+
+import lombok.Builder;
+import lombok.Data;
+import lombok.NoArgsConstructor;
+
+@Data
+@NoArgsConstructor
+public class Search {
+    private String tag;
+    private Long count;
+
+    @Builder
+    public Search(String tag, Long count) {
+        this.tag = tag;
+        this.count = count;
+    }
+}

--- a/src/main/java/com/zoooohs/instagramclone/domain/hashtag/dto/Search.java
+++ b/src/main/java/com/zoooohs/instagramclone/domain/hashtag/dto/Search.java
@@ -1,13 +1,17 @@
 package com.zoooohs.instagramclone.domain.hashtag.dto;
 
+import io.swagger.v3.oas.annotations.media.Schema;
 import lombok.Builder;
 import lombok.Data;
 import lombok.NoArgsConstructor;
 
+@Schema(name = "HashTagSearchDTO")
 @Data
 @NoArgsConstructor
 public class Search {
+    @Schema(description = "tag 이름")
     private String tag;
+    @Schema(description = "해쉬 태그가 사용되 게시글 개수")
     private Long count;
 
     @Builder

--- a/src/main/java/com/zoooohs/instagramclone/domain/hashtag/entity/HashTagEntity.java
+++ b/src/main/java/com/zoooohs/instagramclone/domain/hashtag/entity/HashTagEntity.java
@@ -1,0 +1,26 @@
+package com.zoooohs.instagramclone.domain.hashtag.entity;
+
+import com.zoooohs.instagramclone.domain.common.entity.BaseEntity;
+import com.zoooohs.instagramclone.domain.post.entity.PostEntity;
+import lombok.*;
+
+import javax.persistence.*;
+
+@Getter
+@Setter
+@Entity(name = "hash_tag")
+@NoArgsConstructor
+public class HashTagEntity extends BaseEntity {
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "post_id", nullable = false)
+    private PostEntity post;
+
+    @Column(name = "tag")
+    private String tag;
+
+    @Builder
+    public HashTagEntity(PostEntity post, String tag) {
+        this.post = post;
+        this.tag = tag;
+    }
+}

--- a/src/main/java/com/zoooohs/instagramclone/domain/hashtag/repository/HashTagRepository.java
+++ b/src/main/java/com/zoooohs/instagramclone/domain/hashtag/repository/HashTagRepository.java
@@ -1,10 +1,17 @@
 package com.zoooohs.instagramclone.domain.hashtag.repository;
 
+import com.zoooohs.instagramclone.domain.hashtag.dto.Search;
 import com.zoooohs.instagramclone.domain.hashtag.entity.HashTagEntity;
+import org.springframework.data.domain.Pageable;
 import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Query;
+import org.springframework.data.repository.query.Param;
 
 import java.util.List;
 
 public interface HashTagRepository extends JpaRepository<HashTagEntity, Long> {
     List<HashTagEntity> findByPostId(Long postId);
+
+    @Query(value = "SELECT new com.zoooohs.instagramclone.domain.hashtag.dto.Search(ht.tag, COUNT(ht.tag)) FROM hash_tag ht WHERE ht.tag LIKE %:tag% GROUP BY ht.tag ORDER BY COUNT(ht.tag) DESC")
+    List<Search> searchLikeTag(@Param("tag") String tag, Pageable pageable);
 }

--- a/src/main/java/com/zoooohs/instagramclone/domain/hashtag/repository/HashTagRepository.java
+++ b/src/main/java/com/zoooohs/instagramclone/domain/hashtag/repository/HashTagRepository.java
@@ -1,0 +1,10 @@
+package com.zoooohs.instagramclone.domain.hashtag.repository;
+
+import com.zoooohs.instagramclone.domain.hashtag.entity.HashTagEntity;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+import java.util.List;
+
+public interface HashTagRepository extends JpaRepository<HashTagEntity, Long> {
+    List<HashTagEntity> findByPostId(Long postId);
+}

--- a/src/main/java/com/zoooohs/instagramclone/domain/hashtag/service/HashTagService.java
+++ b/src/main/java/com/zoooohs/instagramclone/domain/hashtag/service/HashTagService.java
@@ -1,0 +1,11 @@
+package com.zoooohs.instagramclone.domain.hashtag.service;
+
+import com.zoooohs.instagramclone.domain.hashtag.dto.HashTagDto;
+
+import java.util.List;
+
+public interface HashTagService {
+    List<String> extract(String content);
+
+    List<HashTagDto> manage(String content, Long postId);
+}

--- a/src/main/java/com/zoooohs/instagramclone/domain/hashtag/service/HashTagService.java
+++ b/src/main/java/com/zoooohs/instagramclone/domain/hashtag/service/HashTagService.java
@@ -1,6 +1,8 @@
 package com.zoooohs.instagramclone.domain.hashtag.service;
 
+import com.zoooohs.instagramclone.domain.common.model.SearchModel;
 import com.zoooohs.instagramclone.domain.hashtag.dto.HashTagDto;
+import com.zoooohs.instagramclone.domain.hashtag.dto.Search;
 
 import java.util.List;
 
@@ -8,4 +10,6 @@ public interface HashTagService {
     List<String> extract(String content);
 
     List<HashTagDto> manage(String content, Long postId);
+
+    List<Search> search(SearchModel searchModel);
 }

--- a/src/main/java/com/zoooohs/instagramclone/domain/hashtag/service/HashTagServiceImpl.java
+++ b/src/main/java/com/zoooohs/instagramclone/domain/hashtag/service/HashTagServiceImpl.java
@@ -1,0 +1,54 @@
+package com.zoooohs.instagramclone.domain.hashtag.service;
+
+import com.zoooohs.instagramclone.domain.hashtag.dto.HashTagDto;
+import com.zoooohs.instagramclone.domain.hashtag.entity.HashTagEntity;
+import com.zoooohs.instagramclone.domain.hashtag.repository.HashTagRepository;
+import lombok.RequiredArgsConstructor;
+import org.modelmapper.ModelMapper;
+import org.springframework.stereotype.Service;
+
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Optional;
+import java.util.function.Predicate;
+import java.util.regex.Matcher;
+import java.util.regex.Pattern;
+import java.util.stream.Collectors;
+
+@Service
+@RequiredArgsConstructor
+public class HashTagServiceImpl implements HashTagService {
+
+    private final HashTagRepository hashTagRepository;
+    private final ModelMapper modelMapper;
+
+    @Override
+    public List<String> extract(String content) { // private 으로 돌려도 되지 않나
+        Pattern hashTagPattern = Pattern.compile("#([\\w\\d-_][\\w\\d-_]*)");
+        Matcher matcher = hashTagPattern.matcher(content);
+
+        List<String> result = new ArrayList<>();
+        while (matcher.find()) {
+            result.add(matcher.group());
+        }
+        return result;
+    }
+
+    @Override
+    public List<HashTagDto> manage(String content, Long postId) {
+        List<HashTagEntity> hashTagEntities = Optional.ofNullable(postId).map(hashTagRepository::findByPostId).orElse(List.of());
+        List<String> tagsInDB = hashTagEntities.stream().map(HashTagEntity::getTag).collect(Collectors.toList()); // db 에 있는 tag
+        List<String> tagsInContent = this.extract(content); // content 에서 찾은 tag
+
+        // content 에서 뽑은 tag 중 db 에 없는 tag 면 새로 저장할 tag
+        List<HashTagEntity> willSave = tagsInContent.stream()
+                .filter(Predicate.not(tagsInDB::contains))
+                .map(t -> HashTagEntity.builder().tag(t).build()).collect(Collectors.toList());
+        // db 에 남아 있을 tag
+        List<HashTagEntity> willRemain = hashTagEntities.stream()
+                .filter(entity -> tagsInContent.contains(entity.getTag())).collect(Collectors.toList());
+
+        willSave.addAll(willRemain);
+        return willSave.stream().map(entity -> modelMapper.map(entity, HashTagDto.class)).collect(Collectors.toList());
+    }
+}

--- a/src/main/java/com/zoooohs/instagramclone/domain/hashtag/service/HashTagServiceImpl.java
+++ b/src/main/java/com/zoooohs/instagramclone/domain/hashtag/service/HashTagServiceImpl.java
@@ -1,10 +1,13 @@
 package com.zoooohs.instagramclone.domain.hashtag.service;
 
+import com.zoooohs.instagramclone.domain.common.model.SearchModel;
 import com.zoooohs.instagramclone.domain.hashtag.dto.HashTagDto;
+import com.zoooohs.instagramclone.domain.hashtag.dto.Search;
 import com.zoooohs.instagramclone.domain.hashtag.entity.HashTagEntity;
 import com.zoooohs.instagramclone.domain.hashtag.repository.HashTagRepository;
 import lombok.RequiredArgsConstructor;
 import org.modelmapper.ModelMapper;
+import org.springframework.data.domain.PageRequest;
 import org.springframework.stereotype.Service;
 
 import java.util.ArrayList;
@@ -50,5 +53,10 @@ public class HashTagServiceImpl implements HashTagService {
 
         willSave.addAll(willRemain);
         return willSave.stream().map(entity -> modelMapper.map(entity, HashTagDto.class)).collect(Collectors.toList());
+    }
+
+    @Override
+    public List<Search> search(SearchModel searchModel) {
+        return hashTagRepository.searchLikeTag(searchModel.getKeyword(), PageRequest.of(searchModel.getIndex(), searchModel.getSize()));
     }
 }

--- a/src/main/java/com/zoooohs/instagramclone/domain/like/controller/LikeController.java
+++ b/src/main/java/com/zoooohs/instagramclone/domain/like/controller/LikeController.java
@@ -4,6 +4,12 @@ import com.zoooohs.instagramclone.domain.like.dto.CommentLikeDto;
 import com.zoooohs.instagramclone.domain.like.dto.PostLikeDto;
 import com.zoooohs.instagramclone.domain.like.service.LikeService;
 import com.zoooohs.instagramclone.domain.user.dto.UserDto;
+import com.zoooohs.instagramclone.exception.ZooooExceptionResponse;
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.media.Content;
+import io.swagger.v3.oas.annotations.media.Schema;
+import io.swagger.v3.oas.annotations.responses.ApiResponse;
+import io.swagger.v3.oas.annotations.responses.ApiResponses;
 import lombok.RequiredArgsConstructor;
 import org.springframework.security.core.annotation.AuthenticationPrincipal;
 import org.springframework.web.bind.annotation.DeleteMapping;
@@ -17,21 +23,73 @@ public class LikeController {
 
     private final LikeService likeService;
 
+    @Operation(summary = "게시글 좋아요", description = "특정 게시글 좋아요.")
+    @ApiResponses(value = {
+            @ApiResponse(
+                    responseCode = "200", description = "좋아요 성공. 좋아요 결과 반환",
+                    content = { @Content(mediaType = "application/json", schema = @Schema(implementation = PostLikeDto.class)) }
+            ),
+            @ApiResponse(
+                    responseCode = "404", description = "게시글을 찾을 수 없음",
+                    content = { @Content(mediaType = "application/json", schema = @Schema(implementation = ZooooExceptionResponse.class)) }
+            ),
+            @ApiResponse(
+                    responseCode = "409", description = "이미 좋아요한 게시글",
+                    content = { @Content(mediaType = "application/json", schema = @Schema(implementation = ZooooExceptionResponse.class)) }
+            ),
+    })
     @PostMapping("/post/{postId}/like")
     public PostLikeDto likePost(@PathVariable Long postId, @AuthenticationPrincipal UserDto userDto) {
         return likeService.likePost(postId, userDto);
     }
 
+    @Operation(summary = "댓글 좋아요", description = "특정 댓글 좋아요.")
+    @ApiResponses(value = {
+            @ApiResponse(
+                    responseCode = "200", description = "좋아요 성공. 좋아요 결과 반환",
+                    content = { @Content(mediaType = "application/json", schema = @Schema(implementation = CommentLikeDto.class)) }
+            ),
+            @ApiResponse(
+                    responseCode = "404", description = "댓글을 찾을 수 없음",
+                    content = { @Content(mediaType = "application/json", schema = @Schema(implementation = ZooooExceptionResponse.class)) }
+            ),
+            @ApiResponse(
+                    responseCode = "409", description = "이미 좋아요한 댓글",
+                    content = { @Content(mediaType = "application/json", schema = @Schema(implementation = ZooooExceptionResponse.class)) }
+            ),
+    })
     @PostMapping("/comment/{commentId}/like")
     public CommentLikeDto likeComment(@PathVariable Long commentId, @AuthenticationPrincipal UserDto userDto) {
         return likeService.likeComment(commentId, userDto);
     }
 
+    @Operation(summary = "게시글 좋아요 취소", description = "특정 게시글 좋아요 취소.")
+    @ApiResponses(value = {
+            @ApiResponse(
+                    responseCode = "200", description = "좋아요 취소 성공. 좋아요 ID 반환",
+                    content = { @Content(mediaType = "application/json", schema = @Schema(implementation = Long.class)) }
+            ),
+            @ApiResponse(
+                    responseCode = "404", description = "좋아요를 찾을 수 없음",
+                    content = { @Content(mediaType = "application/json", schema = @Schema(implementation = ZooooExceptionResponse.class)) }
+            ),
+    })
     @DeleteMapping("/post/{postId}/like")
     public Long unlike(@PathVariable Long postId, @AuthenticationPrincipal UserDto userDto) {
         return likeService.unlikePost(postId, userDto);
     }
 
+    @Operation(summary = "댓글 좋아요 취소", description = "특정 댓글 좋아요 취소.")
+    @ApiResponses(value = {
+            @ApiResponse(
+                    responseCode = "200", description = "좋아요 취소 성공. 좋아요 ID 반환",
+                    content = { @Content(mediaType = "application/json", schema = @Schema(implementation = Long.class)) }
+            ),
+            @ApiResponse(
+                    responseCode = "404", description = "좋아요를 찾을 수 없음",
+                    content = { @Content(mediaType = "application/json", schema = @Schema(implementation = ZooooExceptionResponse.class)) }
+            ),
+    })
     @DeleteMapping("/comment/{commentId}/like")
     public Long unlikeComment(@PathVariable Long commentId, @AuthenticationPrincipal UserDto userDto) {
         return likeService.unlikeComment(commentId, userDto);

--- a/src/main/java/com/zoooohs/instagramclone/domain/like/service/LikeServiceImpl.java
+++ b/src/main/java/com/zoooohs/instagramclone/domain/like/service/LikeServiceImpl.java
@@ -18,6 +18,8 @@ import lombok.RequiredArgsConstructor;
 import org.modelmapper.ModelMapper;
 import org.springframework.stereotype.Service;
 
+import org.springframework.transaction.annotation.Transactional;
+
 @Service
 @RequiredArgsConstructor
 public class LikeServiceImpl implements LikeService {
@@ -28,6 +30,7 @@ public class LikeServiceImpl implements LikeService {
     private final CommentLikeRepository commentLikeRepository;
     private final ModelMapper modelMapper;
 
+    @Transactional
     @Override
     public PostLikeDto likePost(Long postId, UserDto userDto) {
         PostEntity post = postRepository.findById(postId).orElseThrow(() -> new ZooooException(ErrorCode.POST_NOT_FOUND));
@@ -40,6 +43,7 @@ public class LikeServiceImpl implements LikeService {
         return modelMapper.map(like, PostLikeDto.class);
     }
 
+    @Transactional
     @Override
     public Long unlikePost(Long postId, UserDto userDto) {
         PostLikeEntity like = postLikeRepository.findByPostIdAndUserId(postId, userDto.getId());
@@ -51,6 +55,7 @@ public class LikeServiceImpl implements LikeService {
         return likeId;
     }
 
+    @Transactional
     @Override
     public CommentLikeDto likeComment(Long commentId, UserDto userDto) {
         CommentEntity comment = commentRepository.findById(commentId).orElseThrow(() -> new ZooooException(ErrorCode.COMMENT_NOT_FOUND));
@@ -63,6 +68,7 @@ public class LikeServiceImpl implements LikeService {
         return modelMapper.map(commentLike, CommentLikeDto.class);
     }
 
+    @Transactional
     @Override
     public Long unlikeComment(Long commentId, UserDto userDto) {
         CommentLikeEntity commentLike = commentLikeRepository.findByCommentIdAndUserId(commentId, userDto.getId());

--- a/src/main/java/com/zoooohs/instagramclone/domain/photo/controller/PhotoController.java
+++ b/src/main/java/com/zoooohs/instagramclone/domain/photo/controller/PhotoController.java
@@ -1,0 +1,29 @@
+package com.zoooohs.instagramclone.domain.photo.controller;
+
+import com.zoooohs.instagramclone.domain.photo.dto.PhotoDto;
+import com.zoooohs.instagramclone.domain.photo.service.PhotoService;
+import com.zoooohs.instagramclone.domain.user.dto.UserDto;
+import com.zoooohs.instagramclone.exception.ErrorCode;
+import com.zoooohs.instagramclone.exception.ZooooException;
+import lombok.RequiredArgsConstructor;
+import org.springframework.security.core.annotation.AuthenticationPrincipal;
+import org.springframework.web.bind.annotation.PathVariable;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestPart;
+import org.springframework.web.bind.annotation.RestController;
+import org.springframework.web.multipart.MultipartFile;
+
+@RestController
+@RequiredArgsConstructor
+public class PhotoController {
+
+    private final PhotoService photoService;
+
+    @PostMapping("/user/{userId}/photo")
+    public PhotoDto.Photo uploadProfile(@PathVariable Long userId, @RequestPart("photo") MultipartFile photo, @AuthenticationPrincipal UserDto userDto) {
+        if (!userId.equals(userDto.getId())) {
+            throw new ZooooException(ErrorCode.USER_NOT_FOUND);
+        }
+        return photoService.uploadProfile(photo, userDto.getId());
+    }
+}

--- a/src/main/java/com/zoooohs/instagramclone/domain/photo/controller/PhotoController.java
+++ b/src/main/java/com/zoooohs/instagramclone/domain/photo/controller/PhotoController.java
@@ -5,7 +5,14 @@ import com.zoooohs.instagramclone.domain.photo.service.PhotoService;
 import com.zoooohs.instagramclone.domain.user.dto.UserDto;
 import com.zoooohs.instagramclone.exception.ErrorCode;
 import com.zoooohs.instagramclone.exception.ZooooException;
+import com.zoooohs.instagramclone.exception.ZooooExceptionResponse;
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.media.Content;
+import io.swagger.v3.oas.annotations.media.Schema;
+import io.swagger.v3.oas.annotations.responses.ApiResponse;
+import io.swagger.v3.oas.annotations.responses.ApiResponses;
 import lombok.RequiredArgsConstructor;
+import org.springframework.http.MediaType;
 import org.springframework.security.core.annotation.AuthenticationPrincipal;
 import org.springframework.web.bind.annotation.PathVariable;
 import org.springframework.web.bind.annotation.PostMapping;
@@ -19,8 +26,26 @@ public class PhotoController {
 
     private final PhotoService photoService;
 
-    @PostMapping("/user/{userId}/photo")
-    public PhotoDto.Photo uploadProfile(@PathVariable Long userId, @RequestPart("photo") MultipartFile photo, @AuthenticationPrincipal UserDto userDto) {
+    @Operation(summary = "사용자 프로필 사진 변경", description = "사용자의 프로필 사진을 업로드하여 변경한다.")
+    @ApiResponses(value = {
+            @ApiResponse(
+                    responseCode = "200", description = "프로필 사진 변경 성공. 사진 변경 결과 반환",
+                    content = { @Content(mediaType = "application/json", schema = @Schema(implementation = PhotoDto.Photo.class)) }
+            ),
+            @ApiResponse(
+                    responseCode = "400", description = "사진이 아닌 데이터를 업로드",
+                    content = { @Content(mediaType = "application/json", schema = @Schema(implementation = ZooooExceptionResponse.class)) }
+            ),
+            @ApiResponse(
+                    responseCode = "404", description = "사용자를 찾을 수 없음",
+                    content = { @Content(mediaType = "application/json", schema = @Schema(implementation = ZooooExceptionResponse.class)) }
+            ),
+    })
+    @PostMapping(value = "/user/{userId}/photo", consumes = MediaType.MULTIPART_FORM_DATA_VALUE)
+    public PhotoDto.Photo uploadProfile(@PathVariable Long userId,
+                                        @Schema(description = "사진 MultipartFile")
+                                        @RequestPart("photo") MultipartFile photo,
+                                        @AuthenticationPrincipal UserDto userDto) {
         if (!userId.equals(userDto.getId())) {
             throw new ZooooException(ErrorCode.USER_NOT_FOUND);
         }

--- a/src/main/java/com/zoooohs/instagramclone/domain/photo/dto/PhotoDto.java
+++ b/src/main/java/com/zoooohs/instagramclone/domain/photo/dto/PhotoDto.java
@@ -1,14 +1,23 @@
 package com.zoooohs.instagramclone.domain.photo.dto;
 
+import lombok.Builder;
 import lombok.Data;
+import lombok.NoArgsConstructor;
 
 import javax.validation.constraints.NotNull;
 
 public class PhotoDto {
     @Data
+    @NoArgsConstructor
     public static class Photo {
         private Long id;
         @NotNull
         private String path;
+
+        @Builder
+        public Photo(Long id, String path) {
+            this.id = id;
+            this.path = path;
+        }
     }
 }

--- a/src/main/java/com/zoooohs/instagramclone/domain/photo/dto/PhotoDto.java
+++ b/src/main/java/com/zoooohs/instagramclone/domain/photo/dto/PhotoDto.java
@@ -1,5 +1,6 @@
 package com.zoooohs.instagramclone.domain.photo.dto;
 
+import io.swagger.v3.oas.annotations.media.Schema;
 import lombok.Builder;
 import lombok.Data;
 import lombok.NoArgsConstructor;
@@ -7,10 +8,14 @@ import lombok.NoArgsConstructor;
 import javax.validation.constraints.NotNull;
 
 public class PhotoDto {
+
+    @Schema(name = "PhotoDto.Photo")
     @Data
     @NoArgsConstructor
     public static class Photo {
         private Long id;
+
+        @Schema(description = "사진을 사용할 수 있는 경로")
         @NotNull
         private String path;
 

--- a/src/main/java/com/zoooohs/instagramclone/domain/photo/entity/PhotoEntity.java
+++ b/src/main/java/com/zoooohs/instagramclone/domain/photo/entity/PhotoEntity.java
@@ -6,6 +6,7 @@ import lombok.*;
 
 import javax.persistence.*;
 import java.util.ArrayList;
+import java.util.HashSet;
 
 @Getter
 @Setter
@@ -24,15 +25,5 @@ public class PhotoEntity extends BaseEntity {
     public PhotoEntity(String path, PostEntity post) {
         this.path = path;
         this.post = post;
-    }
-
-    public void setPost(PostEntity post) {
-        this.post = post;
-        if (post.getPhotos() == null) {
-            post.setPhotos(new ArrayList<>());
-        }
-        if (!post.getPhotos().contains(this)) {
-            post.getPhotos().add(this);
-        }
     }
 }

--- a/src/main/java/com/zoooohs/instagramclone/domain/photo/service/PhotoService.java
+++ b/src/main/java/com/zoooohs/instagramclone/domain/photo/service/PhotoService.java
@@ -1,9 +1,12 @@
 package com.zoooohs.instagramclone.domain.photo.service;
 
 import com.zoooohs.instagramclone.domain.photo.dto.PhotoDto;
+import org.springframework.web.multipart.MultipartFile;
 
 import java.util.List;
 
 public interface PhotoService {
     List<PhotoDto.Photo> saveAll(List<String> photoIds);
+
+    PhotoDto.Photo uploadProfile(MultipartFile photo, Long userId);
 }

--- a/src/main/java/com/zoooohs/instagramclone/domain/photo/service/PhotoServiceImpl.java
+++ b/src/main/java/com/zoooohs/instagramclone/domain/photo/service/PhotoServiceImpl.java
@@ -1,14 +1,21 @@
 package com.zoooohs.instagramclone.domain.photo.service;
 
+import com.zoooohs.instagramclone.domain.file.service.StorageService;
 import com.zoooohs.instagramclone.domain.photo.dto.PhotoDto;
 import com.zoooohs.instagramclone.domain.photo.entity.PhotoEntity;
 import com.zoooohs.instagramclone.domain.photo.repository.PhotoRepository;
+import com.zoooohs.instagramclone.domain.user.entity.UserEntity;
+import com.zoooohs.instagramclone.domain.user.repository.UserRepository;
+import com.zoooohs.instagramclone.exception.ErrorCode;
+import com.zoooohs.instagramclone.exception.ZooooException;
 import lombok.RequiredArgsConstructor;
 import org.modelmapper.ModelMapper;
-import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.http.MediaType;
 import org.springframework.stereotype.Service;
+import org.springframework.web.multipart.MultipartFile;
 
 import java.util.List;
+import java.util.Optional;
 import java.util.stream.Collectors;
 
 @RequiredArgsConstructor
@@ -16,6 +23,8 @@ import java.util.stream.Collectors;
 public class PhotoServiceImpl implements PhotoService {
 
     private final PhotoRepository photoRepository;
+    private final UserRepository userRepository;
+    private final StorageService storageService;
     private final ModelMapper modelMapper;
 
     @Override
@@ -31,5 +40,20 @@ public class PhotoServiceImpl implements PhotoService {
         return photoEntities.stream()
                 .map(entity -> this.modelMapper.map(entity, PhotoDto.Photo.class))
                 .collect(Collectors.toList());
+    }
+
+    @Override
+    public PhotoDto.Photo uploadProfile(MultipartFile photo, Long userId) {
+        if (!photo.getContentType().equals(MediaType.IMAGE_JPEG_VALUE) && !photo.getContentType().equals(MediaType.IMAGE_PNG_VALUE)) {
+            throw new ZooooException(ErrorCode.INVALID_FILE_TYPE);
+        }
+        UserEntity user = userRepository.findById(userId).orElseThrow(() -> new ZooooException(ErrorCode.USER_NOT_FOUND));
+        Optional<PhotoEntity> oldPhoto = Optional.ofNullable(user.getPhoto());
+        return Optional.ofNullable(storageService.store(List.of(photo))).map(this::saveAll).map(photos -> photos.get(0)).map(photoDto -> {
+            user.setPhoto(modelMapper.map(photoDto, PhotoEntity.class));
+            userRepository.save(user);
+            oldPhoto.ifPresent(entity -> photoRepository.delete(entity));
+            return photoDto;
+        }).orElse(null);
     }
 }

--- a/src/main/java/com/zoooohs/instagramclone/domain/photo/service/PhotoServiceImpl.java
+++ b/src/main/java/com/zoooohs/instagramclone/domain/photo/service/PhotoServiceImpl.java
@@ -14,6 +14,7 @@ import org.springframework.http.MediaType;
 import org.springframework.stereotype.Service;
 import org.springframework.web.multipart.MultipartFile;
 
+import org.springframework.transaction.annotation.Transactional;
 import java.util.List;
 import java.util.Optional;
 import java.util.stream.Collectors;
@@ -27,6 +28,7 @@ public class PhotoServiceImpl implements PhotoService {
     private final StorageService storageService;
     private final ModelMapper modelMapper;
 
+    @Transactional
     @Override
     public List<PhotoDto.Photo> saveAll(List<String> photoIds) {
         List<PhotoEntity> photoEntities = photoIds.stream().map(id -> {
@@ -42,6 +44,7 @@ public class PhotoServiceImpl implements PhotoService {
                 .collect(Collectors.toList());
     }
 
+    @Transactional
     @Override
     public PhotoDto.Photo uploadProfile(MultipartFile photo, Long userId) {
         if (!photo.getContentType().equals(MediaType.IMAGE_JPEG_VALUE) && !photo.getContentType().equals(MediaType.IMAGE_PNG_VALUE)) {

--- a/src/main/java/com/zoooohs/instagramclone/domain/photo/service/PhotoServiceImpl.java
+++ b/src/main/java/com/zoooohs/instagramclone/domain/photo/service/PhotoServiceImpl.java
@@ -52,7 +52,11 @@ public class PhotoServiceImpl implements PhotoService {
         return Optional.ofNullable(storageService.store(List.of(photo))).map(this::saveAll).map(photos -> photos.get(0)).map(photoDto -> {
             user.setPhoto(modelMapper.map(photoDto, PhotoEntity.class));
             userRepository.save(user);
-            oldPhoto.ifPresent(entity -> photoRepository.delete(entity));
+            oldPhoto.ifPresent(entity -> {
+                String oldPath = entity.getPath();
+                photoRepository.delete(entity);
+                storageService.delete(oldPath);
+            });
             return photoDto;
         }).orElse(null);
     }

--- a/src/main/java/com/zoooohs/instagramclone/domain/post/controller/PostController.java
+++ b/src/main/java/com/zoooohs/instagramclone/domain/post/controller/PostController.java
@@ -17,7 +17,7 @@ import java.util.List;
 public class PostController {
     private final PostService postService;
 
-    @PostMapping(value = "/post")
+    @PostMapping("/post")
     public PostDto.Post create(@RequestParam("description") @NotNull String description, @RequestPart("files") List<MultipartFile> files, @AuthenticationPrincipal UserDto userDto) {
         PostDto.Post result = this.postService.create(PostDto.Post.builder().description(description).build(), files, userDto);
         return result;

--- a/src/main/java/com/zoooohs/instagramclone/domain/post/controller/PostController.java
+++ b/src/main/java/com/zoooohs/instagramclone/domain/post/controller/PostController.java
@@ -5,7 +5,15 @@ import com.zoooohs.instagramclone.domain.common.model.SearchModel;
 import com.zoooohs.instagramclone.domain.post.dto.PostDto;
 import com.zoooohs.instagramclone.domain.post.service.PostService;
 import com.zoooohs.instagramclone.domain.user.dto.UserDto;
+import com.zoooohs.instagramclone.exception.ZooooExceptionResponse;
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.media.ArraySchema;
+import io.swagger.v3.oas.annotations.media.Content;
+import io.swagger.v3.oas.annotations.media.Schema;
+import io.swagger.v3.oas.annotations.responses.ApiResponse;
+import io.swagger.v3.oas.annotations.responses.ApiResponses;
 import lombok.RequiredArgsConstructor;
+import org.springframework.http.MediaType;
 import org.springframework.security.core.annotation.AuthenticationPrincipal;
 import org.springframework.web.bind.annotation.*;
 import org.springframework.web.multipart.MultipartFile;
@@ -18,27 +26,77 @@ import java.util.List;
 public class PostController {
     private final PostService postService;
 
-    @PostMapping("/post")
-    public PostDto.Post create(@RequestParam("description") @NotNull String description, @RequestPart("files") List<MultipartFile> files, @AuthenticationPrincipal UserDto userDto) {
+    @Operation(summary = "게시글 작성", description = "새로운 개시글 작성.")
+    @ApiResponses(value = {
+            @ApiResponse(
+                    responseCode = "200", description = "작성 성공. 게시글 작성 결과 반환",
+                    content = { @Content(mediaType = "application/json", schema = @Schema(implementation = PostDto.Post.class)) }
+            ),
+            @ApiResponse(
+                    responseCode = "400", description = "이미지가 아닌 데이터 업로드",
+                    content = { @Content(mediaType = "application/json", schema = @Schema(implementation = ZooooExceptionResponse.class)) }
+            ),
+    })
+    @PostMapping(value = "/post", consumes = MediaType.MULTIPART_FORM_DATA_VALUE )
+    public PostDto.Post create(@RequestParam("description") @NotNull String description,
+                               @Schema(description = "사진 MultipartFile List")
+                               @RequestPart("files") List<MultipartFile> files,
+                               @AuthenticationPrincipal UserDto userDto) {
         PostDto.Post result = this.postService.create(PostDto.Post.builder().description(description).build(), files, userDto);
         return result;
     }
 
+    @Operation(summary = "게시글 피드 불러오기", description = "팔로잉 중인 사람들의 게시글 혹은 해쉬태그로 검색한 게시글 피드를 불러온다.")
+    @ApiResponses(value = {
+            @ApiResponse(
+                    responseCode = "200", description = "피드 불러오기 성공. 게시글 리스트 반환",
+                    content = { @Content(mediaType = "application/json", array = @ArraySchema(schema = @Schema(implementation = PostDto.Post.class))) }
+            ),
+    })
     @GetMapping("/post")
     public List<PostDto.Post> getFeeds(@ModelAttribute SearchModel searchModel, @AuthenticationPrincipal UserDto userDto) {
         return this.postService.getFeeds(userDto.getId(), searchModel);
     }
 
+    @Operation(summary = "특정 사용자의 게시글 불러오기", description = "특정 사용자의 게시글 리스트를 불러온다.")
+    @ApiResponses(value = {
+            @ApiResponse(
+                    responseCode = "200", description = "불러오기 성공. 게시글 리스트 반환",
+                    content = { @Content(mediaType = "application/json", array = @ArraySchema(schema = @Schema(implementation = PostDto.Post.class))) }
+            ),
+    })
     @GetMapping("/user/{userId}/post")
     public List<PostDto.Post> findAllByUserId(@PathVariable Long userId, @ModelAttribute PageModel pageModel, @AuthenticationPrincipal UserDto userDto) {
         return this.postService.findByUserId(userId, pageModel, userDto.getId());
     }
 
+    @Operation(summary = "게시글 설명 수정", description = "게시글의 설명을 수정한다.")
+    @ApiResponses(value = {
+            @ApiResponse(
+                    responseCode = "200", description = "작성 성공. 게시글 작성 결과 반환",
+                    content = { @Content(mediaType = "application/json", schema = @Schema(implementation = PostDto.Post.class)) }
+            ),
+            @ApiResponse(
+                    responseCode = "404", description = "존재하지 않는 게시글",
+                    content = { @Content(mediaType = "application/json", schema = @Schema(implementation = ZooooExceptionResponse.class)) }
+            ),
+    })
     @PatchMapping("/post/{postId}/description")
     public PostDto.Post updateDescription(@PathVariable Long postId, @RequestBody PostDto.Post post, @AuthenticationPrincipal UserDto userDto) {
         return this.postService.updateDescription(postId, post, userDto);
     }
 
+    @Operation(summary = "게시글 삭제", description = "게시글을 삭제한다.")
+    @ApiResponses(value = {
+            @ApiResponse(
+                    responseCode = "200", description = "삭제 성공. 게시글 ID 반환",
+                    content = { @Content(mediaType = "application/json", schema = @Schema(implementation = Long.class)) }
+            ),
+            @ApiResponse(
+                    responseCode = "404", description = "존재하지 않는 게시글",
+                    content = { @Content(mediaType = "application/json", schema = @Schema(implementation = ZooooExceptionResponse.class)) }
+            ),
+    })
     @DeleteMapping("/post/{postId}")
     public Long deleteById(@PathVariable Long postId, @AuthenticationPrincipal UserDto userDto) {
         return this.postService.deleteById(postId, userDto.getId());

--- a/src/main/java/com/zoooohs/instagramclone/domain/post/controller/PostController.java
+++ b/src/main/java/com/zoooohs/instagramclone/domain/post/controller/PostController.java
@@ -5,12 +5,10 @@ import com.zoooohs.instagramclone.domain.post.dto.PostDto;
 import com.zoooohs.instagramclone.domain.post.service.PostService;
 import com.zoooohs.instagramclone.domain.user.dto.UserDto;
 import lombok.RequiredArgsConstructor;
-import org.springframework.http.MediaType;
 import org.springframework.security.core.annotation.AuthenticationPrincipal;
 import org.springframework.web.bind.annotation.*;
 import org.springframework.web.multipart.MultipartFile;
 
-import javax.validation.Valid;
 import javax.validation.constraints.NotNull;
 import java.util.List;
 
@@ -26,13 +24,13 @@ public class PostController {
     }
 
     @GetMapping("/post")
-    public List<PostDto.Post> read(@ModelAttribute PageModel pageModel, @AuthenticationPrincipal UserDto userDto) {
-        return this.postService.findAllExceptSelf(userDto.getId(), pageModel);
+    public List<PostDto.Post> getFeeds(@ModelAttribute PageModel pageModel, @AuthenticationPrincipal UserDto userDto) {
+        return this.postService.getFeeds(userDto.getId(), pageModel);
     }
 
     @GetMapping("/user/{userId}/post")
-    public List<PostDto.Post> findAllByUserId(@PathVariable Long userId, @ModelAttribute PageModel pageModel) {
-        return this.postService.findByUserId(userId, pageModel);
+    public List<PostDto.Post> findAllByUserId(@PathVariable Long userId, @ModelAttribute PageModel pageModel, @AuthenticationPrincipal UserDto userDto) {
+        return this.postService.findByUserId(userId, pageModel, userDto.getId());
     }
 
     @PatchMapping("/post/{postId}/description")

--- a/src/main/java/com/zoooohs/instagramclone/domain/post/controller/PostController.java
+++ b/src/main/java/com/zoooohs/instagramclone/domain/post/controller/PostController.java
@@ -1,6 +1,7 @@
 package com.zoooohs.instagramclone.domain.post.controller;
 
 import com.zoooohs.instagramclone.domain.common.model.PageModel;
+import com.zoooohs.instagramclone.domain.common.model.SearchModel;
 import com.zoooohs.instagramclone.domain.post.dto.PostDto;
 import com.zoooohs.instagramclone.domain.post.service.PostService;
 import com.zoooohs.instagramclone.domain.user.dto.UserDto;
@@ -24,8 +25,8 @@ public class PostController {
     }
 
     @GetMapping("/post")
-    public List<PostDto.Post> getFeeds(@ModelAttribute PageModel pageModel, @AuthenticationPrincipal UserDto userDto) {
-        return this.postService.getFeeds(userDto.getId(), pageModel);
+    public List<PostDto.Post> getFeeds(@ModelAttribute SearchModel searchModel, @AuthenticationPrincipal UserDto userDto) {
+        return this.postService.getFeeds(userDto.getId(), searchModel);
     }
 
     @GetMapping("/user/{userId}/post")

--- a/src/main/java/com/zoooohs/instagramclone/domain/post/dto/PostDto.java
+++ b/src/main/java/com/zoooohs/instagramclone/domain/post/dto/PostDto.java
@@ -5,6 +5,7 @@ import com.zoooohs.instagramclone.domain.user.dto.UserDto;
 import lombok.Builder;
 import lombok.Data;
 import lombok.NoArgsConstructor;
+import lombok.experimental.Accessors;
 
 import javax.validation.constraints.NotNull;
 import java.util.ArrayList;
@@ -19,13 +20,18 @@ public class PostDto {
         private String description;
         private List<PhotoDto.Photo> photos;
         private UserDto.Feed user;
+        private Long likeCount;
+        @Accessors(fluent = true)
+        private Boolean isLiked;
 
         @Builder
-        public Post(Long id, String description, UserDto.Feed user) {
+        public Post(Long id, String description, List<PhotoDto.Photo> photos, UserDto.Feed user, Long likeCount, Boolean isLiked) {
             this.id = id;
             this.description = description;
+            this.photos = photos;
             this.user = user;
-            this.photos = new ArrayList<>();
+            this.likeCount = likeCount;
+            this.isLiked = isLiked;
         }
     }
 }

--- a/src/main/java/com/zoooohs/instagramclone/domain/post/dto/PostDto.java
+++ b/src/main/java/com/zoooohs/instagramclone/domain/post/dto/PostDto.java
@@ -2,26 +2,37 @@ package com.zoooohs.instagramclone.domain.post.dto;
 
 import com.zoooohs.instagramclone.domain.photo.dto.PhotoDto;
 import com.zoooohs.instagramclone.domain.user.dto.UserDto;
+import io.swagger.v3.oas.annotations.media.Schema;
 import lombok.Builder;
 import lombok.Data;
 import lombok.NoArgsConstructor;
 import lombok.experimental.Accessors;
 
 import javax.validation.constraints.NotNull;
-import java.util.ArrayList;
 import java.util.List;
 
 public class PostDto {
+    @Schema(name = "PostDto.Post")
     @Data
     @NoArgsConstructor
     public static class Post {
         private Long id;
+
         @NotNull
+        @Schema(description = "게시글 설명 (글 내용)")
         private String description;
+
+        @Schema(description = "게시글 사진 리스트")
         private List<PhotoDto.Photo> photos;
+
+        @Schema(description = "게시글 작성자")
         private UserDto.Feed user;
+
+        @Schema(description = "게시글 좋아요 개수")
         private Long likeCount;
+
         @Accessors(fluent = true)
+        @Schema(name = "liked", description = "내가 좋아요를 눌렀는지 여부")
         private Boolean isLiked;
 
         @Builder

--- a/src/main/java/com/zoooohs/instagramclone/domain/post/entity/PostEntity.java
+++ b/src/main/java/com/zoooohs/instagramclone/domain/post/entity/PostEntity.java
@@ -1,6 +1,7 @@
 package com.zoooohs.instagramclone.domain.post.entity;
 
 import com.zoooohs.instagramclone.domain.common.entity.BaseEntity;
+import com.zoooohs.instagramclone.domain.hashtag.entity.HashTagEntity;
 import com.zoooohs.instagramclone.domain.like.entity.PostLikeEntity;
 import com.zoooohs.instagramclone.domain.photo.entity.PhotoEntity;
 import com.zoooohs.instagramclone.domain.user.entity.UserEntity;
@@ -24,6 +25,9 @@ import java.util.Set;
                 @NamedAttributeNode(value = "photos"),
                 @NamedAttributeNode(value = "likes"),
         }),
+        @NamedEntityGraph(name = "post-all-child", attributeNodes = {
+                @NamedAttributeNode(value = "hashTags"),
+        }),
 })
 public class PostEntity extends BaseEntity {
     // TODO: hash tag 알 수 있는 방법 추가하기
@@ -34,14 +38,33 @@ public class PostEntity extends BaseEntity {
     @JoinColumn(name = "user_id", nullable = false)
     private UserEntity user;
 
+    // TODO: cascade 범위 다시 고려
     @OneToMany(mappedBy = "post", cascade = CascadeType.ALL, fetch = FetchType.LAZY)
     private Set<PhotoEntity> photos = new HashSet<>();
 
     @OneToMany(mappedBy = "post", fetch = FetchType.LAZY)
     private Set<PostLikeEntity> likes = new HashSet<>();
 
+    @OneToMany(mappedBy = "post", fetch = FetchType.LAZY, cascade = {CascadeType.MERGE, CascadeType.PERSIST}, orphanRemoval = true)
+    private Set<HashTagEntity> hashTags = new HashSet<>();
+
     public Long getLikeCount() {
         return (long) likes.size();
+    }
+
+    public void setHashTags(Set<HashTagEntity> hashTags) {
+        this.hashTags.clear();
+        if (hashTags != null) {
+            this.hashTags.addAll(hashTags);
+        }
+//        if (hashTags == null) {
+//            return;
+//        }
+        for (HashTagEntity hashTag: hashTags) {
+            if (hashTag.getPost() == null) {
+                hashTag.setPost(this);
+            }
+        }
     }
 
     public void setPhotos(Set<PhotoEntity> photos) {

--- a/src/main/java/com/zoooohs/instagramclone/domain/post/entity/PostEntity.java
+++ b/src/main/java/com/zoooohs/instagramclone/domain/post/entity/PostEntity.java
@@ -10,9 +10,7 @@ import lombok.NoArgsConstructor;
 import lombok.Setter;
 
 import javax.persistence.*;
-import java.util.ArrayList;
 import java.util.HashSet;
-import java.util.List;
 import java.util.Set;
 
 @Getter
@@ -48,6 +46,9 @@ public class PostEntity extends BaseEntity {
 
     public void setPhotos(Set<PhotoEntity> photos) {
         this.photos = photos;
+        if (photos == null) {
+            return;
+        }
         for (PhotoEntity photo: photos) {
             if (photo.getPost() == null) {
                 photo.setPost(this);

--- a/src/main/java/com/zoooohs/instagramclone/domain/post/entity/PostEntity.java
+++ b/src/main/java/com/zoooohs/instagramclone/domain/post/entity/PostEntity.java
@@ -1,6 +1,7 @@
 package com.zoooohs.instagramclone.domain.post.entity;
 
 import com.zoooohs.instagramclone.domain.common.entity.BaseEntity;
+import com.zoooohs.instagramclone.domain.like.entity.PostLikeEntity;
 import com.zoooohs.instagramclone.domain.photo.entity.PhotoEntity;
 import com.zoooohs.instagramclone.domain.user.entity.UserEntity;
 import lombok.Builder;
@@ -10,7 +11,9 @@ import lombok.Setter;
 
 import javax.persistence.*;
 import java.util.ArrayList;
+import java.util.HashSet;
 import java.util.List;
+import java.util.Set;
 
 @Getter
 @Setter
@@ -21,6 +24,7 @@ import java.util.List;
         @NamedEntityGraph(name = "post-feed", attributeNodes = {
                 @NamedAttributeNode(value = "user"),
                 @NamedAttributeNode(value = "photos"),
+                @NamedAttributeNode(value = "likes"),
         }),
 })
 public class PostEntity extends BaseEntity {
@@ -32,10 +36,17 @@ public class PostEntity extends BaseEntity {
     @JoinColumn(name = "user_id", nullable = false)
     private UserEntity user;
 
-    @OneToMany(mappedBy = "post", cascade = CascadeType.ALL)
-    private List<PhotoEntity> photos;
+    @OneToMany(mappedBy = "post", cascade = CascadeType.ALL, fetch = FetchType.LAZY)
+    private Set<PhotoEntity> photos = new HashSet<>();
 
-    public void setPhotos(List<PhotoEntity> photos) {
+    @OneToMany(mappedBy = "post", fetch = FetchType.LAZY)
+    private Set<PostLikeEntity> likes = new HashSet<>();
+
+    public Long getLikeCount() {
+        return (long) likes.size();
+    }
+
+    public void setPhotos(Set<PhotoEntity> photos) {
         this.photos = photos;
         for (PhotoEntity photo: photos) {
             if (photo.getPost() == null) {
@@ -49,6 +60,6 @@ public class PostEntity extends BaseEntity {
         this.id = id;
         this.description = description;
         this.user = user;
-        this.photos = new ArrayList<>();
+        this.photos = new HashSet<>();
     }
 }

--- a/src/main/java/com/zoooohs/instagramclone/domain/post/repository/PostRepository.java
+++ b/src/main/java/com/zoooohs/instagramclone/domain/post/repository/PostRepository.java
@@ -22,4 +22,12 @@ public interface PostRepository extends JpaRepository<PostEntity, Long> {
 
     @EntityGraph("post-feed")
     PostEntity findByIdAndUserId(Long postId, Long userId);
+
+    @EntityGraph("post-feed")
+    @Query("SELECT p FROM PostEntity p WHERE p.user.id = :userId ORDER BY p.id DESC")
+    List<PostEntity> findMinesAndFollowUsers(Long userId, Pageable pageable);
+
+    @EntityGraph("post-feed")
+    @Query("SELECT p FROM PostEntity p WHERE p.user.id IN :userIds ORDER BY p.id DESC")
+    List<PostEntity> findAllByUserId(@Param("userIds") List<Long> userIds, Pageable pageable);
 }

--- a/src/main/java/com/zoooohs/instagramclone/domain/post/repository/PostRepository.java
+++ b/src/main/java/com/zoooohs/instagramclone/domain/post/repository/PostRepository.java
@@ -9,6 +9,7 @@ import org.springframework.data.repository.query.Param;
 import org.springframework.stereotype.Repository;
 
 import java.util.List;
+import java.util.Optional;
 
 @Repository
 public interface PostRepository extends JpaRepository<PostEntity, Long> {
@@ -30,4 +31,8 @@ public interface PostRepository extends JpaRepository<PostEntity, Long> {
     @EntityGraph("post-feed")
     @Query("SELECT p FROM PostEntity p WHERE p.user.id IN :userIds ORDER BY p.id DESC")
     List<PostEntity> findAllByUserId(@Param("userIds") List<Long> userIds, Pageable pageable);
+
+    @EntityGraph("post-all-child")
+    @Query("SELECT p FROM PostEntity p WHERE p.id = :id")
+    Optional<PostEntity> findByIdForDelete(@Param("id") Long postId);
 }

--- a/src/main/java/com/zoooohs/instagramclone/domain/post/repository/PostRepository.java
+++ b/src/main/java/com/zoooohs/instagramclone/domain/post/repository/PostRepository.java
@@ -35,4 +35,8 @@ public interface PostRepository extends JpaRepository<PostEntity, Long> {
     @EntityGraph("post-all-child")
     @Query("SELECT p FROM PostEntity p WHERE p.id = :id")
     Optional<PostEntity> findByIdForDelete(@Param("id") Long postId);
+
+    @EntityGraph("post-feed")
+    @Query("SELECT ht.post FROM hash_tag ht JOIN PostEntity p ON ht.post.id = p.id WHERE ht.tag = :tag ORDER BY p.id DESC")
+    List<PostEntity> findAllByTag(@Param("tag") String tag, Pageable pageable);
 }

--- a/src/main/java/com/zoooohs/instagramclone/domain/post/service/PostService.java
+++ b/src/main/java/com/zoooohs/instagramclone/domain/post/service/PostService.java
@@ -1,6 +1,7 @@
 package com.zoooohs.instagramclone.domain.post.service;
 
 import com.zoooohs.instagramclone.domain.common.model.PageModel;
+import com.zoooohs.instagramclone.domain.common.model.SearchModel;
 import com.zoooohs.instagramclone.domain.post.dto.PostDto;
 import com.zoooohs.instagramclone.domain.user.dto.UserDto;
 import org.springframework.web.multipart.MultipartFile;
@@ -19,5 +20,5 @@ public interface PostService {
 
     Long deleteById(Long postId, Long userId);
 
-    List<PostDto.Post> getFeeds(Long userId, PageModel pageModel);
+    List<PostDto.Post> getFeeds(Long userId, SearchModel searchModel);
 }

--- a/src/main/java/com/zoooohs/instagramclone/domain/post/service/PostService.java
+++ b/src/main/java/com/zoooohs/instagramclone/domain/post/service/PostService.java
@@ -13,9 +13,11 @@ public interface PostService {
     // 자신의 게시물을 제외한 모든 게시물 가져오기
     public List<PostDto.Post> findAllExceptSelf(Long userId, PageModel pageModel);
 
-    public List<PostDto.Post> findByUserId(Long userId, PageModel pageModel);
+    public List<PostDto.Post> findByUserId(Long postUserId, PageModel pageModel, Long userId);
 
     PostDto.Post updateDescription(Long postId, PostDto.Post post, UserDto userDto);
 
     Long deleteById(Long postId, Long userId);
+
+    List<PostDto.Post> getFeeds(Long userId, PageModel pageModel);
 }

--- a/src/main/java/com/zoooohs/instagramclone/domain/post/service/PostServiceImpl.java
+++ b/src/main/java/com/zoooohs/instagramclone/domain/post/service/PostServiceImpl.java
@@ -77,6 +77,7 @@ public class PostServiceImpl implements PostService {
         return makePostDto(postEntities, userId);
     }
 
+    @Transactional
     @Override
     public PostDto.Post updateDescription(Long postId, PostDto.Post post, UserDto userDto) {
         PostEntity postEntity = this.postRepository.findById(postId).orElseThrow(() -> new ZooooException(ErrorCode.POST_NOT_FOUND));
@@ -90,6 +91,7 @@ public class PostServiceImpl implements PostService {
         return result;
     }
 
+    @Transactional
     @Override
     public Long deleteById(Long postId, Long userId) {
         PostEntity postEntity = this.postRepository.findByIdAndUserId(postId, userId);

--- a/src/main/java/com/zoooohs/instagramclone/domain/post/service/PostServiceImpl.java
+++ b/src/main/java/com/zoooohs/instagramclone/domain/post/service/PostServiceImpl.java
@@ -83,7 +83,9 @@ public class PostServiceImpl implements PostService {
         if (postEntity == null) {
             throw new ZooooException(ErrorCode.POST_NOT_FOUND);
         }
+        List<String> photoPaths = postEntity.getPhotos().stream().map(PhotoEntity::getPath).collect(Collectors.toList());
         this.postRepository.delete(postEntity);
+        photoPaths.stream().forEach(storageService::delete);
         return postId;
     }
 

--- a/src/main/java/com/zoooohs/instagramclone/domain/post/service/PostServiceImpl.java
+++ b/src/main/java/com/zoooohs/instagramclone/domain/post/service/PostServiceImpl.java
@@ -2,6 +2,7 @@ package com.zoooohs.instagramclone.domain.post.service;
 
 import com.zoooohs.instagramclone.domain.common.model.PageModel;
 import com.zoooohs.instagramclone.domain.file.service.StorageService;
+import com.zoooohs.instagramclone.domain.follow.repository.FollowRepository;
 import com.zoooohs.instagramclone.domain.photo.entity.PhotoEntity;
 import com.zoooohs.instagramclone.domain.post.dto.PostDto;
 import com.zoooohs.instagramclone.domain.post.entity.PostEntity;
@@ -19,12 +20,14 @@ import org.springframework.transaction.annotation.Transactional;
 import org.springframework.web.multipart.MultipartFile;
 
 import java.util.List;
+import java.util.Set;
 import java.util.stream.Collectors;
 
 @Service
 @RequiredArgsConstructor
 public class PostServiceImpl implements PostService {
     private final PostRepository postRepository;
+    private final FollowRepository followRepository;
     private final ModelMapper modelMapper;
     private final StorageService storageService;
 
@@ -32,7 +35,7 @@ public class PostServiceImpl implements PostService {
     @Override
     public PostDto.Post create(PostDto.Post postDto, List<MultipartFile> files, UserDto userDto) {
         List<String> photoPaths = this.storageService.store(files);
-        List<PhotoEntity> photos = photoPaths.stream().map(path -> PhotoEntity.builder().path(path).build()).collect(Collectors.toList());
+        Set<PhotoEntity> photos = photoPaths.stream().map(path -> PhotoEntity.builder().path(path).build()).collect(Collectors.toSet());
         UserEntity user = this.modelMapper.map(userDto, UserEntity.class);
         PostEntity post = this.modelMapper.map(postDto, PostEntity.class);
         post.setUser(user);
@@ -50,10 +53,10 @@ public class PostServiceImpl implements PostService {
 
     @Transactional(readOnly = true)
     @Override
-    public List<PostDto.Post> findByUserId(Long userId, PageModel pageModel) {
+    public List<PostDto.Post> findByUserId(Long postUserId, PageModel pageModel, Long userId) {
         // TODO: userDto 추가 -> 현재 유저가 볼 수 있는 게시글만 보게 -> 팔로우 기능 이후
-        List<PostEntity> postEntities = this.postRepository.findByUserId(userId, PageRequest.of(pageModel.getIndex(), pageModel.getSize()));
-        return postEntities.stream().map(entity -> this.modelMapper.map(entity, PostDto.Post.class)).collect(Collectors.toList());
+        List<PostEntity> postEntities = this.postRepository.findByUserId(postUserId, PageRequest.of(pageModel.getIndex(), pageModel.getSize()));
+        return makePostDto(postEntities, userId);
     }
 
     @Override
@@ -76,5 +79,22 @@ public class PostServiceImpl implements PostService {
         }
         this.postRepository.delete(postEntity);
         return postId;
+    }
+
+    @Override
+    public List<PostDto.Post> getFeeds(Long userId, PageModel pageModel) {
+        List<Long> userIds = followRepository.findByUserId(userId).stream().map(entity -> entity.getFollowUser().getId()).collect(Collectors.toList());
+        userIds.add(userId);
+        List<PostEntity> postEntities = postRepository.findAllByUserId(userIds, PageRequest.of(pageModel.getIndex(), pageModel.getSize()));
+        return makePostDto(postEntities, userId);
+    }
+
+    private List<PostDto.Post> makePostDto(List<PostEntity> postEntities, Long userId) {
+        return postEntities.stream().map(entity -> {
+            PostDto.Post post = this.modelMapper.map(entity, PostDto.Post.class);
+            boolean isLiked = entity.getLikes().stream().filter(like -> like.getUser().getId().equals(userId)).findFirst().isPresent();
+            post.isLiked(isLiked);
+            return post;
+        }).collect(Collectors.toList());
     }
 }

--- a/src/main/java/com/zoooohs/instagramclone/domain/post/service/PostServiceImpl.java
+++ b/src/main/java/com/zoooohs/instagramclone/domain/post/service/PostServiceImpl.java
@@ -1,6 +1,7 @@
 package com.zoooohs.instagramclone.domain.post.service;
 
 import com.zoooohs.instagramclone.domain.common.model.PageModel;
+import com.zoooohs.instagramclone.domain.common.model.SearchModel;
 import com.zoooohs.instagramclone.domain.file.service.StorageService;
 import com.zoooohs.instagramclone.domain.follow.repository.FollowRepository;
 import com.zoooohs.instagramclone.domain.hashtag.entity.HashTagEntity;
@@ -87,10 +88,15 @@ public class PostServiceImpl implements PostService {
     }
 
     @Override
-    public List<PostDto.Post> getFeeds(Long userId, PageModel pageModel) {
-        List<Long> userIds = followRepository.findByUserId(userId).stream().map(entity -> entity.getFollowUser().getId()).collect(Collectors.toList());
-        userIds.add(userId);
-        List<PostEntity> postEntities = postRepository.findAllByUserId(userIds, PageRequest.of(pageModel.getIndex(), pageModel.getSize()));
+    public List<PostDto.Post> getFeeds(Long userId, SearchModel searchModel) {
+        List<PostEntity> postEntities;
+        if (searchModel.getKeyword() == null) {
+            List<Long> userIds = followRepository.findByUserId(userId).stream().map(entity -> entity.getFollowUser().getId()).collect(Collectors.toList());
+            userIds.add(userId);
+            postEntities = postRepository.findAllByUserId(userIds, PageRequest.of(searchModel.getIndex(), searchModel.getSize()));
+        } else {
+            postEntities = postRepository.findAllByTag(searchModel.getKeyword(), PageRequest.of(searchModel.getIndex(), searchModel.getSize()));
+        }
         return makePostDto(postEntities, userId);
     }
 

--- a/src/main/java/com/zoooohs/instagramclone/domain/post/service/PostServiceImpl.java
+++ b/src/main/java/com/zoooohs/instagramclone/domain/post/service/PostServiceImpl.java
@@ -3,6 +3,8 @@ package com.zoooohs.instagramclone.domain.post.service;
 import com.zoooohs.instagramclone.domain.common.model.PageModel;
 import com.zoooohs.instagramclone.domain.file.service.StorageService;
 import com.zoooohs.instagramclone.domain.follow.repository.FollowRepository;
+import com.zoooohs.instagramclone.domain.hashtag.entity.HashTagEntity;
+import com.zoooohs.instagramclone.domain.hashtag.service.HashTagService;
 import com.zoooohs.instagramclone.domain.photo.entity.PhotoEntity;
 import com.zoooohs.instagramclone.domain.post.dto.PostDto;
 import com.zoooohs.instagramclone.domain.post.entity.PostEntity;
@@ -30,6 +32,7 @@ public class PostServiceImpl implements PostService {
     private final FollowRepository followRepository;
     private final ModelMapper modelMapper;
     private final StorageService storageService;
+    private final HashTagService hashTagService;
 
     @Transactional
     @Override
@@ -40,6 +43,7 @@ public class PostServiceImpl implements PostService {
         PostEntity post = this.modelMapper.map(postDto, PostEntity.class);
         post.setUser(user);
         post.setPhotos(photos);
+        post.setHashTags(getHashTagEntities(post.getDescription(), post.getId()));
         post = this.postRepository.save(post);
         return this.modelMapper.map(post, PostDto.Post.class);
     }
@@ -66,6 +70,7 @@ public class PostServiceImpl implements PostService {
             throw new ZooooException(ErrorCode.POST_NOT_FOUND);
         }
         postEntity.setDescription(post.getDescription());
+        postEntity.setHashTags(getHashTagEntities(post.getDescription(), postId ));
         postEntity = this.postRepository.save(postEntity);
         PostDto.Post result = this.modelMapper.map(postEntity, PostDto.Post.class);
         return result;
@@ -96,5 +101,10 @@ public class PostServiceImpl implements PostService {
             post.isLiked(isLiked);
             return post;
         }).collect(Collectors.toList());
+    }
+
+    private Set<HashTagEntity> getHashTagEntities(String content, Long postId) {
+        return hashTagService.manage(content, postId).stream()
+                .map(dto -> modelMapper.map(dto, HashTagEntity.class)).collect(Collectors.toSet());
     }
 }

--- a/src/main/java/com/zoooohs/instagramclone/domain/user/controller/UserController.java
+++ b/src/main/java/com/zoooohs/instagramclone/domain/user/controller/UserController.java
@@ -3,6 +3,13 @@ package com.zoooohs.instagramclone.domain.user.controller;
 import com.zoooohs.instagramclone.domain.common.model.SearchModel;
 import com.zoooohs.instagramclone.domain.user.dto.UserDto;
 import com.zoooohs.instagramclone.domain.user.service.UserService;
+import com.zoooohs.instagramclone.exception.ZooooExceptionResponse;
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.media.ArraySchema;
+import io.swagger.v3.oas.annotations.media.Content;
+import io.swagger.v3.oas.annotations.media.Schema;
+import io.swagger.v3.oas.annotations.responses.ApiResponse;
+import io.swagger.v3.oas.annotations.responses.ApiResponses;
 import lombok.RequiredArgsConstructor;
 import org.springframework.security.core.annotation.AuthenticationPrincipal;
 import org.springframework.web.bind.annotation.*;
@@ -15,16 +22,42 @@ import java.util.List;
 public class UserController {
     private final UserService userService;
 
+    @Operation(summary = "사용자 정보 조회", description = "특정 사용자의 상세 정보를 조회한다.")
+    @ApiResponses(value = {
+            @ApiResponse(
+                    responseCode = "200", description = "조회 성공. 사용자 상세 정보 결과 반환",
+                    content = { @Content(mediaType = "application/json", schema = @Schema(implementation = UserDto.Info.class)) }
+            ),
+            @ApiResponse(
+                    responseCode = "404", description = "존재하지 않는 사용자",
+                    content = { @Content(mediaType = "application/json", schema = @Schema(implementation = ZooooExceptionResponse.class)) }
+            ),
+    })
     @GetMapping("/user/{userId}")
     public UserDto.Info getInfo(@PathVariable Long userId) {
         return this.userService.getInfo(userId);
     }
 
+    @Operation(summary = "사용자 리스트 조회", description = "사용자 리스트를 조회하거나, 이름으로 사용자 리스트 검색")
+    @ApiResponses(value = {
+            @ApiResponse(
+                    responseCode = "200", description = "조회 성공. 사용자 리스트 조회 결과 반환",
+                    content = { @Content(mediaType = "application/json", array = @ArraySchema(schema = @Schema(implementation = UserDto.Info.class))) }
+            ),
+    })
     @GetMapping("/user")
     public List<UserDto.Info> getUsers(@ModelAttribute @Valid SearchModel searchModel) {
         return userService.getUsers(searchModel);
     }
 
+    // TODO: user Id를 받아서 작동하도록 변경해야함
+    @Operation(summary = "사용자 바이오 수정", description = "자신의 바이오 정보를 변경한다.")
+    @ApiResponses(value = {
+            @ApiResponse(
+                    responseCode = "200", description = "수정 성공. 수정 정보 결과 반환",
+                    content = { @Content(mediaType = "application/json", schema = @Schema(implementation = UserDto.Info.class)) }
+            ),
+    })
     @PatchMapping("/user/bio")
     public UserDto.Info updateBio(@RequestBody UserDto.Info userDto, @AuthenticationPrincipal UserDto authUserDto) {
         return this.userService.updateBio(userDto.getBio(), authUserDto);

--- a/src/main/java/com/zoooohs/instagramclone/domain/user/controller/UserController.java
+++ b/src/main/java/com/zoooohs/instagramclone/domain/user/controller/UserController.java
@@ -1,10 +1,14 @@
 package com.zoooohs.instagramclone.domain.user.controller;
 
+import com.zoooohs.instagramclone.domain.common.model.SearchModel;
 import com.zoooohs.instagramclone.domain.user.dto.UserDto;
 import com.zoooohs.instagramclone.domain.user.service.UserService;
 import lombok.RequiredArgsConstructor;
 import org.springframework.security.core.annotation.AuthenticationPrincipal;
 import org.springframework.web.bind.annotation.*;
+
+import javax.validation.Valid;
+import java.util.List;
 
 @RequiredArgsConstructor
 @RestController
@@ -14,6 +18,11 @@ public class UserController {
     @GetMapping("/user/{userId}")
     public UserDto.Info getInfo(@PathVariable Long userId) {
         return this.userService.getInfo(userId);
+    }
+
+    @GetMapping("/user")
+    public List<UserDto.Info> getUsers(@ModelAttribute @Valid SearchModel searchModel) {
+        return userService.getUsers(searchModel);
     }
 
     @PatchMapping("/user/bio")

--- a/src/main/java/com/zoooohs/instagramclone/domain/user/dto/UserDto.java
+++ b/src/main/java/com/zoooohs/instagramclone/domain/user/dto/UserDto.java
@@ -1,9 +1,11 @@
 package com.zoooohs.instagramclone.domain.user.dto;
 
 import com.zoooohs.instagramclone.domain.photo.dto.PhotoDto;
+import io.swagger.v3.oas.annotations.media.Schema;
 import lombok.Builder;
 import lombok.Data;
 import lombok.NoArgsConstructor;
+import lombok.Setter;
 
 @Data
 @NoArgsConstructor
@@ -19,6 +21,7 @@ public class UserDto {
         this.name = name;
     }
 
+    @Schema(name = "UserDto.Feed", description = "게시글 피드 리스트에 유저 정보를 나타내기 위한 DTO")
     @Data
     @NoArgsConstructor
     public static class Feed {
@@ -32,12 +35,17 @@ public class UserDto {
         }
     }
 
+    @Schema(name = "UserDto.Info", description = "유저 세부 정보를 나타내기 위한 DTO")
     @Data
     @NoArgsConstructor
     public static class Info {
         private Long id;
         private String name;
+
+        @Schema(description = "바이오")
         private String bio;
+
+        @Schema(description = "프로필 사진")
         private PhotoDto.Photo photo;
 
         @Builder

--- a/src/main/java/com/zoooohs/instagramclone/domain/user/dto/UserDto.java
+++ b/src/main/java/com/zoooohs/instagramclone/domain/user/dto/UserDto.java
@@ -38,14 +38,14 @@ public class UserDto {
         private Long id;
         private String name;
         private String bio;
-        private PhotoDto.Photo profilePhoto;
+        private PhotoDto.Photo photo;
 
         @Builder
-        public Info(Long id, String name, String bio, PhotoDto.Photo profilePhoto) {
+        public Info(Long id, String name, String bio, PhotoDto.Photo photo) {
             this.id = id;
             this.name = name;
             this.bio = bio;
-            this.profilePhoto = profilePhoto;
+            this.photo = photo;
         }
     }
 

--- a/src/main/java/com/zoooohs/instagramclone/domain/user/dto/UserDto.java
+++ b/src/main/java/com/zoooohs/instagramclone/domain/user/dto/UserDto.java
@@ -33,11 +33,20 @@ public class UserDto {
     }
 
     @Data
+    @NoArgsConstructor
     public static class Info {
         private Long id;
         private String name;
         private String bio;
         private PhotoDto.Photo profilePhoto;
+
+        @Builder
+        public Info(Long id, String name, String bio, PhotoDto.Photo profilePhoto) {
+            this.id = id;
+            this.name = name;
+            this.bio = bio;
+            this.profilePhoto = profilePhoto;
+        }
     }
 
     public String getUsername() {

--- a/src/main/java/com/zoooohs/instagramclone/domain/user/entity/UserEntity.java
+++ b/src/main/java/com/zoooohs/instagramclone/domain/user/entity/UserEntity.java
@@ -6,7 +6,6 @@ import lombok.Builder;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
 import lombok.Setter;
-import org.springframework.data.jpa.repository.EntityGraph;
 import org.springframework.security.core.GrantedAuthority;
 import org.springframework.security.core.userdetails.UserDetails;
 
@@ -21,7 +20,7 @@ import java.util.Collection;
 @Entity(name = "user")
 @NamedEntityGraphs({
         @NamedEntityGraph(name = "user-info", attributeNodes = {
-                @NamedAttributeNode("profilePhoto")
+                @NamedAttributeNode("photo")
         })
 })
 public class UserEntity extends BaseEntity implements UserDetails {
@@ -41,9 +40,9 @@ public class UserEntity extends BaseEntity implements UserDetails {
     @Column(name = "bio")
     private String bio;
 
-    @ManyToOne(fetch = FetchType.LAZY)
-    @JoinColumn(name = "profile_photo_id")
-    private PhotoEntity profilePhoto;
+    @OneToOne(fetch = FetchType.LAZY, orphanRemoval = true)
+    @JoinColumn(name = "photo_id")
+    private PhotoEntity photo;
 
     @Builder
     public UserEntity(Long id, String email, String password, String name) {

--- a/src/main/java/com/zoooohs/instagramclone/domain/user/repository/UserRepository.java
+++ b/src/main/java/com/zoooohs/instagramclone/domain/user/repository/UserRepository.java
@@ -1,10 +1,13 @@
 package com.zoooohs.instagramclone.domain.user.repository;
 
 import com.zoooohs.instagramclone.domain.user.entity.UserEntity;
+import org.springframework.data.domain.Pageable;
 import org.springframework.data.jpa.repository.EntityGraph;
 import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Query;
 import org.springframework.stereotype.Repository;
 
+import java.util.List;
 import java.util.Optional;
 
 @Repository
@@ -17,4 +20,7 @@ public interface UserRepository extends JpaRepository<UserEntity, Long> {
 
     @EntityGraph("user-info")
     Optional<UserEntity> findById(Long id);
+
+    @EntityGraph("user-info")
+    List<UserEntity> findByNameIgnoreCaseContaining(String keyword, Pageable pageable);
 }

--- a/src/main/java/com/zoooohs/instagramclone/domain/user/service/UserService.java
+++ b/src/main/java/com/zoooohs/instagramclone/domain/user/service/UserService.java
@@ -1,9 +1,14 @@
 package com.zoooohs.instagramclone.domain.user.service;
 
+import com.zoooohs.instagramclone.domain.common.model.SearchModel;
 import com.zoooohs.instagramclone.domain.user.dto.UserDto;
+
+import java.util.List;
 
 public interface UserService {
     public UserDto.Info getInfo(Long userId);
 
     public UserDto.Info updateBio(String bio, UserDto authUserDto);
+
+    List<UserDto.Info> getUsers(SearchModel searchModel);
 }

--- a/src/main/java/com/zoooohs/instagramclone/domain/user/service/UserServiceImpl.java
+++ b/src/main/java/com/zoooohs/instagramclone/domain/user/service/UserServiceImpl.java
@@ -1,6 +1,7 @@
 package com.zoooohs.instagramclone.domain.user.service;
 
 import com.zoooohs.instagramclone.domain.common.model.SearchModel;
+import com.zoooohs.instagramclone.domain.common.type.SearchKeyType;
 import com.zoooohs.instagramclone.domain.user.dto.UserDto;
 import com.zoooohs.instagramclone.domain.user.entity.UserEntity;
 import com.zoooohs.instagramclone.domain.user.repository.UserRepository;
@@ -13,7 +14,9 @@ import org.springframework.data.domain.Pageable;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
+import java.util.Collection;
 import java.util.List;
+import java.util.Optional;
 import java.util.stream.Collectors;
 
 @RequiredArgsConstructor
@@ -41,8 +44,12 @@ public class UserServiceImpl implements UserService {
 
     @Override
     public List<UserDto.Info> getUsers(SearchModel searchModel) {
-        Pageable pageable = PageRequest.of(searchModel.getIndex(), searchModel.getSize());
-        List<UserEntity> users = userRepository.findByNameIgnoreCaseContaining(searchModel.getKeyword(), pageable);
-        return users.stream().map(entity -> modelMapper.map(entity, UserDto.Info.class)).collect(Collectors.toList());
+        List<UserEntity> users = null;
+        if (searchModel.getSearchKey().equals(SearchKeyType.NAME)) {
+            Pageable pageable = PageRequest.of(searchModel.getIndex(), searchModel.getSize());
+            users = userRepository.findByNameIgnoreCaseContaining(searchModel.getKeyword(), pageable);
+        }
+        return Optional.ofNullable(users).map(Collection::stream)
+                .map(stream -> stream.map(entity -> modelMapper.map(entity, UserDto.Info.class)).collect(Collectors.toList())).orElse(List.of());
     }
 }

--- a/src/main/java/com/zoooohs/instagramclone/domain/user/service/UserServiceImpl.java
+++ b/src/main/java/com/zoooohs/instagramclone/domain/user/service/UserServiceImpl.java
@@ -1,5 +1,6 @@
 package com.zoooohs.instagramclone.domain.user.service;
 
+import com.zoooohs.instagramclone.domain.common.model.SearchModel;
 import com.zoooohs.instagramclone.domain.user.dto.UserDto;
 import com.zoooohs.instagramclone.domain.user.entity.UserEntity;
 import com.zoooohs.instagramclone.domain.user.repository.UserRepository;
@@ -7,8 +8,13 @@ import com.zoooohs.instagramclone.exception.ErrorCode;
 import com.zoooohs.instagramclone.exception.ZooooException;
 import lombok.RequiredArgsConstructor;
 import org.modelmapper.ModelMapper;
+import org.springframework.data.domain.PageRequest;
+import org.springframework.data.domain.Pageable;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
+
+import java.util.List;
+import java.util.stream.Collectors;
 
 @RequiredArgsConstructor
 @Service
@@ -31,5 +37,12 @@ public class UserServiceImpl implements UserService {
         user.setBio(bio);
         user = this.userRepository.save(user);
         return this.modelMapper.map(user, UserDto.Info.class);
+    }
+
+    @Override
+    public List<UserDto.Info> getUsers(SearchModel searchModel) {
+        Pageable pageable = PageRequest.of(searchModel.getIndex(), searchModel.getSize());
+        List<UserEntity> users = userRepository.findByNameIgnoreCaseContaining(searchModel.getKeyword(), pageable);
+        return users.stream().map(entity -> modelMapper.map(entity, UserDto.Info.class)).collect(Collectors.toList());
     }
 }

--- a/src/main/java/com/zoooohs/instagramclone/exception/ErrorCode.java
+++ b/src/main/java/com/zoooohs/instagramclone/exception/ErrorCode.java
@@ -19,6 +19,8 @@ public enum ErrorCode {
     SIGN_UP_DUPLICATED_EMAIL_OR_NAME(HttpStatus.CONFLICT, "중복 된 email 혹은 name 입니다."),
     ALREADY_LIKED_POST(HttpStatus.CONFLICT, "이미 좋아요 한 게시글 입니다."),
     ALREADY_LIKED_COMMENT(HttpStatus.CONFLICT, "이미 좋아요 한 댓글 입니다."),
+    ALREADY_FOLLOWED_USER(HttpStatus.CONFLICT, "이미 팔로우 한 사용자 입니다."),
+    FOLLOWING_SELF(HttpStatus.CONFLICT, "자기 자신은 이미 평생 친구 입니다."),
 
     // 500 INTERNAL
     INTERNAL_ERROR(HttpStatus.INTERNAL_SERVER_ERROR, "서버 내부 오류"),

--- a/src/main/java/com/zoooohs/instagramclone/exception/ErrorCode.java
+++ b/src/main/java/com/zoooohs/instagramclone/exception/ErrorCode.java
@@ -14,13 +14,14 @@ public enum ErrorCode {
     POST_NOT_FOUND(HttpStatus.NOT_FOUND, "게시글을 찾을 수 없습니다."),
     COMMENT_NOT_FOUND(HttpStatus.NOT_FOUND, "댓글을 찾을 수 없습니다."),
     LIKE_NOT_FOUND(HttpStatus.NOT_FOUND, "좋아요를 찾을 수 없습니다."),
+    FOLLOW_NOT_FOUND(HttpStatus.NOT_FOUND, "팔로우를 찾을 수 없습니다."),
 
     // 409 CONFLICT
     SIGN_UP_DUPLICATED_EMAIL_OR_NAME(HttpStatus.CONFLICT, "중복 된 email 혹은 name 입니다."),
     ALREADY_LIKED_POST(HttpStatus.CONFLICT, "이미 좋아요 한 게시글 입니다."),
     ALREADY_LIKED_COMMENT(HttpStatus.CONFLICT, "이미 좋아요 한 댓글 입니다."),
     ALREADY_FOLLOWED_USER(HttpStatus.CONFLICT, "이미 팔로우 한 사용자 입니다."),
-    FOLLOWING_SELF(HttpStatus.CONFLICT, "자기 자신은 이미 평생 친구 입니다."),
+    FOLLOWING_SELF(HttpStatus.CONFLICT, "자기 자신은 영원한 친구 입니다."),
 
     // 500 INTERNAL
     INTERNAL_ERROR(HttpStatus.INTERNAL_SERVER_ERROR, "서버 내부 오류"),

--- a/src/main/java/com/zoooohs/instagramclone/exception/ErrorCode.java
+++ b/src/main/java/com/zoooohs/instagramclone/exception/ErrorCode.java
@@ -5,6 +5,9 @@ import org.springframework.http.HttpStatus;
 
 @Getter
 public enum ErrorCode {
+    // 400 BAD_REQUEST
+    INVALID_FILE_TYPE(HttpStatus.BAD_REQUEST, "올바르지 않은 파일 타입 입니다."),
+
     // 401 UNAUTHORIZED
     TOKEN_EXPIRED(HttpStatus.UNAUTHORIZED, "만료된 토큰 입니다."),
 

--- a/src/main/resources/application.yaml
+++ b/src/main/resources/application.yaml
@@ -29,7 +29,7 @@ logging:
           hibernate: info
 
 instagram-clone:
-  version: 0.0.1
+  version: 1.0.0
   storage:
     filesystem: ${STORAGE_FS}
   jwt:

--- a/src/main/resources/application.yaml
+++ b/src/main/resources/application.yaml
@@ -29,6 +29,7 @@ logging:
           hibernate: info
 
 instagram-clone:
+  version: 0.0.1
   storage:
     filesystem: ${STORAGE_FS}
   jwt:

--- a/src/main/resources/application.yaml
+++ b/src/main/resources/application.yaml
@@ -28,5 +28,13 @@ logging:
         org:
           hibernate: info
 
-storage:
-  filesystem: ${STORAGE_FS}
+instagram-clone:
+  storage:
+    filesystem: ${STORAGE_FS}
+  jwt:
+    access-token:
+      key: ${ACCESS_TOKEN_KEY}
+      valid-time: ${ACCESS_TOKEN_VALID_TIME:86400000} # default: 1 day
+    refresh-token:
+      key: ${REFRESH_TOKEN_KEY}
+      valid-time: ${REFRESH_TOKEN_VALID_TIME:432000000} # default: 5 days

--- a/src/main/resources/application.yaml
+++ b/src/main/resources/application.yaml
@@ -19,6 +19,8 @@ spring:
     multipart:
       maxFileSize: 10MB
       maxRequestSize: 10MB
+  jackson:
+    property-naming-strategy: SNAKE_CASE
 
 
 logging:

--- a/src/test/java/com/zoooohs/instagramclone/domain/auth/controller/AuthControllerTest.java
+++ b/src/test/java/com/zoooohs/instagramclone/domain/auth/controller/AuthControllerTest.java
@@ -1,6 +1,7 @@
 package com.zoooohs.instagramclone.domain.auth.controller;
 
 import com.fasterxml.jackson.databind.ObjectMapper;
+import com.fasterxml.jackson.databind.PropertyNamingStrategies;
 import com.zoooohs.instagramclone.configuration.JwtTokenProvider;
 import com.zoooohs.instagramclone.domain.auth.dto.AuthDto;
 import com.zoooohs.instagramclone.domain.auth.service.AuthService;
@@ -89,6 +90,8 @@ public class AuthControllerTest {
 
     @Test
     public void refreshTest() throws Exception {
+        objectMapper.setPropertyNamingStrategy(PropertyNamingStrategies.SNAKE_CASE);
+
         String url = "/auth/refresh";
         AuthDto.Token token = getToken();
 
@@ -96,7 +99,7 @@ public class AuthControllerTest {
 
         mockMvc.perform(MockMvcRequestBuilders.post(url)
                 .contentType(MediaType.APPLICATION_JSON)
-                .content(objectMapper.writeValueAsBytes(token)))
+                .content(objectMapper.writeValueAsString(token)))
                 .andExpect(MockMvcResultMatchers.status().isOk());
     }
 

--- a/src/test/java/com/zoooohs/instagramclone/domain/comment/repository/CommentRepositoryTest.java
+++ b/src/test/java/com/zoooohs/instagramclone/domain/comment/repository/CommentRepositoryTest.java
@@ -1,6 +1,8 @@
 package com.zoooohs.instagramclone.domain.comment.repository;
 
 import com.zoooohs.instagramclone.domain.comment.entity.CommentEntity;
+import com.zoooohs.instagramclone.domain.like.entity.CommentLikeEntity;
+import com.zoooohs.instagramclone.domain.like.repository.CommentLikeRepository;
 import com.zoooohs.instagramclone.domain.post.entity.PostEntity;
 import com.zoooohs.instagramclone.domain.post.repository.PostRepository;
 import com.zoooohs.instagramclone.domain.user.entity.UserEntity;
@@ -17,6 +19,7 @@ import org.springframework.data.jpa.repository.config.EnableJpaAuditing;
 import org.springframework.security.crypto.factory.PasswordEncoderFactories;
 import org.springframework.security.crypto.password.PasswordEncoder;
 
+import javax.persistence.EntityManager;
 import java.util.ArrayList;
 import java.util.Date;
 import java.util.List;
@@ -36,6 +39,12 @@ public class CommentRepositoryTest {
 
     @Autowired
     PostRepository postRepository;
+
+    @Autowired
+    CommentLikeRepository commentLikeRepository;
+
+    @Autowired
+    EntityManager entityManager;
 
     private PasswordEncoder passwordEncoder;
     private PostEntity post;
@@ -92,6 +101,41 @@ public class CommentRepositoryTest {
 
         assertNotEquals(null, actual);
         assertEquals(pageSize, actual.size());
+    }
+
+    @DisplayName("findByPostId comment entity list SELECT 할때 likes같이 반환")
+    @Test
+    public void findByPostIdWithLikesTest() {
+        List<CommentEntity> testList = new ArrayList<>();
+        for (int i = 0; i < 20; i++) {
+            CommentEntity comment = new CommentEntity();
+            comment.setContent("content");
+            comment.setUser(user);
+            comment.setPost(post);
+            testList.add(comment);
+        }
+
+        this.commentRepository.saveAll(testList);
+
+        CommentLikeEntity commentLike = new CommentLikeEntity();
+        commentLike.setComment(testList.get(0));
+        commentLike.setUser(user);
+
+        commentLikeRepository.save(commentLike);
+
+        entityManager.flush();
+        entityManager.clear();
+
+
+        int pageSize = 20;
+        Pageable pageable = PageRequest.of(0, pageSize);
+
+        List<CommentEntity> actual = this.commentRepository.findByPostId(post.getId(), pageable);
+
+        assertNotEquals(null, actual);
+        assertEquals(pageSize, actual.size());
+        assertEquals(1, actual.get(0).getLikeCount());
+        assertTrue(actual.get(0).getLikes().stream().filter(l -> l.getUser().getId().equals(user.getId())).findFirst().isPresent());
     }
 
     @DisplayName("commentRepository.findByIdAndUserId commentId, userId 받아와서 해당 유저의 댓글 가져오는 기능 테스트")

--- a/src/test/java/com/zoooohs/instagramclone/domain/file/service/BaseStorageServiceTest.java
+++ b/src/test/java/com/zoooohs/instagramclone/domain/file/service/BaseStorageServiceTest.java
@@ -76,5 +76,17 @@ public abstract class BaseStorageServiceTest {
         assertFalse(exists);
     }
 
+    @DisplayName("여러 경로를 넘기면 한번의 bulk 삭제 서비스")
+    @Test
+    public void deleteAllTest() {
+        List<String> paths = storageService.store(files);
+
+        storageService.deleteAll(paths);
+
+        for (String path: paths) {
+            assertFalse(storageService.exists(path));
+        }
+    }
+
     public void bucketExistTest() {}
 }

--- a/src/test/java/com/zoooohs/instagramclone/domain/file/service/BaseStorageServiceTest.java
+++ b/src/test/java/com/zoooohs/instagramclone/domain/file/service/BaseStorageServiceTest.java
@@ -7,15 +7,20 @@ import org.springframework.http.MediaType;
 import org.springframework.mock.web.MockMultipartFile;
 import org.springframework.web.multipart.MultipartFile;
 
+import java.io.File;
 import java.util.ArrayList;
 import java.util.List;
 
-import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.*;
+import static org.junit.jupiter.api.Assertions.assertFalse;
 
 public abstract class BaseStorageServiceTest {
     protected StorageService storageService;
     protected List<MultipartFile> files;
     protected String bucketName;
+
+    private MockMultipartFile file;
+    private String path;
 
     public void setUp() {
         files = new ArrayList<>();
@@ -25,6 +30,10 @@ public abstract class BaseStorageServiceTest {
                             MediaType.TEXT_PLAIN_VALUE, String.format("some contents %d", i).getBytes());
             files.add(file);
         }
+        file = new MockMultipartFile("files", "file_name.txt",
+                MediaType.TEXT_PLAIN_VALUE, "contents".getBytes());
+
+        path = storageService.store(List.of(file)).get(0);
     }
 
     @DisplayName("multi part storage에 저장후 경로 받아오기")
@@ -37,6 +46,34 @@ public abstract class BaseStorageServiceTest {
             String path = actual.get(i);
             assertEquals(FileUtils.getExtension(files.get(i).getOriginalFilename()), FileUtils.getExtension(path));
         }
+    }
+
+    @DisplayName("path 넘겨서 오브젝트 존재 유무 boolean 반환하는 서비스")
+    @Test
+    public void existsTest() {
+        String notExistPath = "nope";
+        String someExistPath = path;
+
+        Boolean expectedFalse = storageService.exists(notExistPath);
+        Boolean expectedTrue = storageService.exists(someExistPath);
+
+        assertFalse(expectedFalse);
+        assertTrue(expectedTrue);
+
+        // tear down
+        File f = new File(someExistPath);
+        if (f.exists()) {
+            f.delete();
+        }
+    }
+
+    @DisplayName("storage service에 path 넘겨서 오브젝트 삭제")
+    @Test
+    public void deleteTest() {
+        storageService.delete(path);
+        Boolean exists = storageService.exists(path);
+
+        assertFalse(exists);
     }
 
     public void bucketExistTest() {}

--- a/src/test/java/com/zoooohs/instagramclone/domain/file/service/FileSystemStorageServiceTest.java
+++ b/src/test/java/com/zoooohs/instagramclone/domain/file/service/FileSystemStorageServiceTest.java
@@ -17,12 +17,12 @@ public class FileSystemStorageServiceTest extends BaseStorageServiceTest {
     @Override
     @BeforeEach
     public void setUp() {
-        super.setUp();
         storageService = new FileSystemStorageServiceImpl();
         bucketName = "bucket-name" + UUID.randomUUID() + "/";
         storageService.setBucketName(bucketName);
         bucket = new File(bucketName);
         bucket.mkdir();
+        super.setUp();
     }
 
     @Override

--- a/src/test/java/com/zoooohs/instagramclone/domain/file/service/S3StorageServiceTest.java
+++ b/src/test/java/com/zoooohs/instagramclone/domain/file/service/S3StorageServiceTest.java
@@ -19,7 +19,6 @@ public class S3StorageServiceTest extends BaseStorageServiceTest {
     @Override
     @BeforeEach
     public void setUp() {
-        super.setUp();
         api = new S3Mock.Builder().withPort(8001).withInMemoryBackend().build();
         api.start();
         AwsClientBuilder.EndpointConfiguration endpoint = new AwsClientBuilder.EndpointConfiguration("http://localhost:8001", "ap-northeast-2");
@@ -33,6 +32,7 @@ public class S3StorageServiceTest extends BaseStorageServiceTest {
         amazonS3Client.createBucket(bucketName);
         storageService = new S3StorageServiceImpl(amazonS3Client);
         storageService.setBucketName(bucketName);
+        super.setUp();
     }
 
     @AfterEach

--- a/src/test/java/com/zoooohs/instagramclone/domain/follow/controller/FollowControllerTest.java
+++ b/src/test/java/com/zoooohs/instagramclone/domain/follow/controller/FollowControllerTest.java
@@ -8,6 +8,7 @@ import com.zoooohs.instagramclone.domain.user.dto.UserDto;
 import com.zoooohs.instagramclone.exception.ErrorCode;
 import com.zoooohs.instagramclone.exception.ZooooException;
 import org.hamcrest.Matchers;
+import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
@@ -20,11 +21,12 @@ import org.springframework.boot.test.mock.mockito.MockBean;
 import org.springframework.context.annotation.ComponentScan;
 import org.springframework.context.annotation.FilterType;
 import org.springframework.test.web.servlet.MockMvc;
+import org.springframework.test.web.servlet.result.MockMvcResultMatchers;
 
 import static org.mockito.BDDMockito.*;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.delete;
 import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.post;
-import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.jsonPath;
-import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.*;
 
 @AutoConfigureMockMvc(addFilters = false)
 @WebMvcTest(
@@ -44,17 +46,26 @@ public class FollowControllerTest {
 
     @MockBean
     FollowService followService;
+    private Long followUserId;
+    private Long userNotFoundId;
+    private String url;
+    private String url404;
+    private String url409Self;
+
+    @BeforeEach
+    public void setUp() {
+        followUserId = 2L;
+        userNotFoundId = 3L;
+        url = String.format("/user/%d/follow", followUserId);
+        url404 = String.format("/user/%d/follow", userNotFoundId);
+        url409Self = String.format("/user/%d/follow", 1L);
+    }
 
     @DisplayName("POST /user/{userId}/follow, jwt를 입력받아 follow json 반환, userId 없으면 404, 이미 follow 한 user면 409 반환")
     @Test
     @WithAuthUser(email = "user1@test.test", id = 1L)
     public void followTest() throws Exception {
-        Long followUserId = 2L;
-        Long userNotFoundId = 3L;
-        String url = String.format("/user/%d/follow", followUserId);
-        String url404 = String.format("/user/%d/follow", userNotFoundId);
         String url409 = String.format("/user/%d/follow", followUserId);
-        String url409Self = String.format("/user/%d/follow", 1L);
 
         given(followService.follow(eq(followUserId), eq(1L))).willReturn(FollowDto.builder().id(1L).follow(UserDto.Info.builder().id(followUserId).build()).build());
         given(followService.follow(eq(userNotFoundId), eq(1L))).willThrow(new ZooooException(ErrorCode.USER_NOT_FOUND));
@@ -79,5 +90,27 @@ public class FollowControllerTest {
         mockMvc.perform(post(url409))
                 .andExpect(status().isConflict())
                 .andExpect(jsonPath("$.code", Matchers.is(ErrorCode.ALREADY_FOLLOWED_USER.name())));
+    }
+
+    @DisplayName("DELETE /user/{followUserId}/follow, jwt 입력 id 반환. follow가 없을 경우 404, 자기 자신을 언팔로우 할 경우 409")
+    @Test
+    @WithAuthUser(email = "user1@test.test", id = 1L)
+    public void unfollowTest() throws Exception {
+
+        given(followService.unfollow(eq(followUserId), eq(1L))).willReturn(1L);
+        given(followService.unfollow(eq(userNotFoundId), eq(1L))).willThrow(new ZooooException(ErrorCode.FOLLOW_NOT_FOUND));
+        given(followService.unfollow(eq(1L), eq(1L))).willThrow(new ZooooException(ErrorCode.FOLLOWING_SELF));
+
+        mockMvc.perform(delete(url))
+                .andExpect(status().isOk())
+                .andExpect(content().string("1"));
+
+        mockMvc.perform(delete(url404))
+                .andExpect(status().isNotFound())
+                .andExpect(jsonPath("$.code", Matchers.is(ErrorCode.FOLLOW_NOT_FOUND.name())));
+
+        mockMvc.perform(delete(url409Self))
+                .andExpect(status().isConflict())
+                .andExpect(jsonPath("$.code", Matchers.is(ErrorCode.FOLLOWING_SELF.name())));
     }
 }

--- a/src/test/java/com/zoooohs/instagramclone/domain/follow/controller/FollowControllerTest.java
+++ b/src/test/java/com/zoooohs/instagramclone/domain/follow/controller/FollowControllerTest.java
@@ -1,0 +1,83 @@
+package com.zoooohs.instagramclone.domain.follow.controller;
+
+import com.zoooohs.instagramclone.configuration.SecurityConfiguration;
+import com.zoooohs.instagramclone.configure.WithAuthUser;
+import com.zoooohs.instagramclone.domain.follow.dto.FollowDto;
+import com.zoooohs.instagramclone.domain.follow.service.FollowService;
+import com.zoooohs.instagramclone.domain.user.dto.UserDto;
+import com.zoooohs.instagramclone.exception.ErrorCode;
+import com.zoooohs.instagramclone.exception.ZooooException;
+import org.hamcrest.Matchers;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.autoconfigure.web.servlet.AutoConfigureMockMvc;
+import org.springframework.boot.test.autoconfigure.web.servlet.WebMvcTest;
+import org.springframework.boot.test.mock.mockito.MockBean;
+import org.springframework.context.annotation.ComponentScan;
+import org.springframework.context.annotation.FilterType;
+import org.springframework.test.web.servlet.MockMvc;
+
+import static org.mockito.BDDMockito.*;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.post;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.jsonPath;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
+
+@AutoConfigureMockMvc(addFilters = false)
+@WebMvcTest(
+        controllers = FollowController.class,
+        excludeFilters = {
+                @ComponentScan.Filter(
+                        type = FilterType.ASSIGNABLE_TYPE,
+                        classes = SecurityConfiguration.class
+                )
+        }
+)
+@ExtendWith(MockitoExtension.class)
+public class FollowControllerTest {
+
+    @Autowired
+    MockMvc mockMvc;
+
+    @MockBean
+    FollowService followService;
+
+    @DisplayName("POST /user/{userId}/follow, jwt를 입력받아 follow json 반환, userId 없으면 404, 이미 follow 한 user면 409 반환")
+    @Test
+    @WithAuthUser(email = "user1@test.test", id = 1L)
+    public void followTest() throws Exception {
+        Long followUserId = 2L;
+        Long userNotFoundId = 3L;
+        String url = String.format("/user/%d/follow", followUserId);
+        String url404 = String.format("/user/%d/follow", userNotFoundId);
+        String url409 = String.format("/user/%d/follow", followUserId);
+        String url409Self = String.format("/user/%d/follow", 1L);
+
+        given(followService.follow(eq(followUserId), eq(1L))).willReturn(FollowDto.builder().id(1L).follow(UserDto.Info.builder().id(followUserId).build()).build());
+        given(followService.follow(eq(userNotFoundId), eq(1L))).willThrow(new ZooooException(ErrorCode.USER_NOT_FOUND));
+        given(followService.follow(eq(1L), eq(1L))).willThrow(new ZooooException(ErrorCode.FOLLOWING_SELF));
+
+        mockMvc.perform(post(url))
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$.id", Matchers.instanceOf(Integer.class)))
+                .andExpect(jsonPath("$.follow_user.id", Matchers.instanceOf(Integer.class)));
+
+        mockMvc.perform(post(url404))
+                .andExpect(status().isNotFound())
+                .andExpect(jsonPath("$.code", Matchers.is(ErrorCode.USER_NOT_FOUND.name())));
+
+
+        mockMvc.perform(post(url409Self))
+                .andExpect(status().isConflict())
+                .andExpect(jsonPath("$.code", Matchers.is(ErrorCode.FOLLOWING_SELF.name())));
+
+        given(followService.follow(eq(followUserId), eq(1L))).willThrow(new ZooooException(ErrorCode.ALREADY_FOLLOWED_USER));
+
+        mockMvc.perform(post(url409))
+                .andExpect(status().isConflict())
+                .andExpect(jsonPath("$.code", Matchers.is(ErrorCode.ALREADY_FOLLOWED_USER.name())));
+    }
+}

--- a/src/test/java/com/zoooohs/instagramclone/domain/follow/repository/FollowRepositoryTest.java
+++ b/src/test/java/com/zoooohs/instagramclone/domain/follow/repository/FollowRepositoryTest.java
@@ -13,6 +13,8 @@ import org.springframework.data.jpa.repository.config.EnableJpaAuditing;
 import org.springframework.security.crypto.factory.PasswordEncoderFactories;
 import org.springframework.security.crypto.password.PasswordEncoder;
 
+import java.util.Optional;
+
 import static org.junit.jupiter.api.Assertions.*;
 
 @EnableJpaAuditing
@@ -64,4 +66,19 @@ public class FollowRepositoryTest {
         assertNotNull(actual);
         assertEquals(followEntity.getId(), actual.getId());
     }
+
+    @DisplayName("follow entity delete test")
+    @Test
+    public void deleteTest() {
+        FollowEntity followEntity = FollowEntity.builder().followUser(followUserEntity).user(userEntity).build();
+        followEntity = followRepository.save(followEntity);
+        followRepository.delete(followEntity);
+
+        FollowEntity actual = followRepository.findByFollowUserIdAndUserId(followUserEntity.getId(), userEntity.getId());
+        Optional<FollowEntity> actual2 = followRepository.findById(followEntity.getId());
+
+        assertNull(actual);
+        assertTrue(actual2.isEmpty());
+    }
+
 }

--- a/src/test/java/com/zoooohs/instagramclone/domain/follow/repository/FollowRepositoryTest.java
+++ b/src/test/java/com/zoooohs/instagramclone/domain/follow/repository/FollowRepositoryTest.java
@@ -1,0 +1,67 @@
+package com.zoooohs.instagramclone.domain.follow.repository;
+
+import com.zoooohs.instagramclone.domain.follow.entity.FollowEntity;
+import com.zoooohs.instagramclone.domain.user.entity.UserEntity;
+import com.zoooohs.instagramclone.domain.user.repository.UserRepository;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.autoconfigure.jdbc.AutoConfigureTestDatabase;
+import org.springframework.boot.test.autoconfigure.orm.jpa.DataJpaTest;
+import org.springframework.data.jpa.repository.config.EnableJpaAuditing;
+import org.springframework.security.crypto.factory.PasswordEncoderFactories;
+import org.springframework.security.crypto.password.PasswordEncoder;
+
+import static org.junit.jupiter.api.Assertions.*;
+
+@EnableJpaAuditing
+@DataJpaTest
+@AutoConfigureTestDatabase(replace = AutoConfigureTestDatabase.Replace.NONE)
+public class FollowRepositoryTest {
+    @Autowired
+    FollowRepository followRepository;
+
+    @Autowired
+    UserRepository userRepository;
+
+    PasswordEncoder passwordEncoder;
+    UserEntity userEntity;
+    UserEntity followUserEntity;
+
+    @BeforeEach
+    public void setUp() {
+        passwordEncoder = PasswordEncoderFactories.createDelegatingPasswordEncoder();
+
+        userEntity = UserEntity.builder()
+                .name("test").email("test@test.test").password(passwordEncoder.encode("passwd")).build();
+        followUserEntity = UserEntity.builder()
+                .name("test2").email("test2@test.test").password(passwordEncoder.encode("passwd")).build();
+        this.userRepository.save(userEntity);
+        this.userRepository.save(followUserEntity);
+    }
+
+    @DisplayName("follow entity save 테스트")
+    @Test
+    public void saveTest() {
+        FollowEntity followEntity = FollowEntity.builder().followUser(followUserEntity).user(userEntity).build();
+
+        FollowEntity actual = followRepository.save(followEntity);
+
+        assertNotNull(actual.getId());
+        assertEquals(followEntity.getFollowUser().getId(), actual.getFollowUser().getId());
+        assertEquals(followEntity.getUser().getId(), actual.getUser().getId());
+    }
+
+    @DisplayName("followUserId, userId 로 followEntity select 테스트")
+    @Test
+    public void findByFollowUserIdAndUserIdTest() {
+        FollowEntity followEntity = FollowEntity.builder().followUser(followUserEntity).user(userEntity).build();
+        followEntity = followRepository.save(followEntity);
+
+        FollowEntity actual = followRepository.findByFollowUserIdAndUserId(followUserEntity.getId(), userEntity.getId());
+
+        assertNotNull(actual);
+        assertEquals(followEntity.getId(), actual.getId());
+    }
+}

--- a/src/test/java/com/zoooohs/instagramclone/domain/follow/repository/FollowRepositoryTest.java
+++ b/src/test/java/com/zoooohs/instagramclone/domain/follow/repository/FollowRepositoryTest.java
@@ -13,6 +13,7 @@ import org.springframework.data.jpa.repository.config.EnableJpaAuditing;
 import org.springframework.security.crypto.factory.PasswordEncoderFactories;
 import org.springframework.security.crypto.password.PasswordEncoder;
 
+import java.util.List;
 import java.util.Optional;
 
 import static org.junit.jupiter.api.Assertions.*;
@@ -79,6 +80,18 @@ public class FollowRepositoryTest {
 
         assertNull(actual);
         assertTrue(actual2.isEmpty());
+    }
+
+    @DisplayName("userId 로 follower entity list select 하는 follow repository")
+    @Test
+    public void findByUserIdTest() {
+        FollowEntity followEntity = FollowEntity.builder().followUser(followUserEntity).user(userEntity).build();
+        followEntity = followRepository.save(followEntity);
+
+        List<FollowEntity> actual = followRepository.findByUserId(userEntity.getId());
+
+        assertEquals(1, actual.size());
+        assertEquals(followEntity.getId(), actual.get(0).getId());
     }
 
 }

--- a/src/test/java/com/zoooohs/instagramclone/domain/follow/service/FollowServiceTest.java
+++ b/src/test/java/com/zoooohs/instagramclone/domain/follow/service/FollowServiceTest.java
@@ -110,4 +110,42 @@ public class FollowServiceTest {
             fail();
         }
     }
+
+    @DisplayName("followUserId, userId 쌍의 follow 있을때 follow entity 삭제후 id 반환")
+    @Test
+    public void unfollowTest() {
+        given(followRepository.findByFollowUserIdAndUserId(followUserId, userId)).willReturn(followEntity);
+
+        Long actual = followService.unfollow(followUserId, userId);
+
+        assertEquals(followEntity.getId(), actual);
+    }
+
+    @DisplayName("followUserId, userId 쌍의 follow 없을 때 FOLLOW_NOT_FOUND throw")
+    @Test
+    public void unfollowFailure404Test() {
+        given(followRepository.findByFollowUserIdAndUserId(followUserId, userId)).willReturn(null);
+
+        try {
+            followService.unfollow(followUserId, userId);
+            fail();
+        } catch (ZooooException e) {
+            assertEquals(ErrorCode.FOLLOW_NOT_FOUND, e.getErrorCode());
+        } catch (Exception e) {
+            fail();
+        }
+    }
+
+    @DisplayName("followUserId == userId 일 경우 FOLLOWING_SELF throw")
+    @Test
+    public void unfollowFailure409Test() {
+        try {
+            followService.unfollow(userId, userId);
+            fail();
+        } catch (ZooooException e) {
+            assertEquals(ErrorCode.FOLLOWING_SELF, e.getErrorCode());
+        } catch (Exception e) {
+            fail();
+        }
+    }
 }

--- a/src/test/java/com/zoooohs/instagramclone/domain/follow/service/FollowServiceTest.java
+++ b/src/test/java/com/zoooohs/instagramclone/domain/follow/service/FollowServiceTest.java
@@ -1,0 +1,113 @@
+package com.zoooohs.instagramclone.domain.follow.service;
+
+import com.zoooohs.instagramclone.domain.follow.dto.FollowDto;
+import com.zoooohs.instagramclone.domain.follow.entity.FollowEntity;
+import com.zoooohs.instagramclone.domain.follow.repository.FollowRepository;
+import com.zoooohs.instagramclone.domain.user.entity.UserEntity;
+import com.zoooohs.instagramclone.domain.user.repository.UserRepository;
+import com.zoooohs.instagramclone.exception.ErrorCode;
+import com.zoooohs.instagramclone.exception.ZooooException;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.Mock;
+import org.mockito.Spy;
+import org.mockito.junit.jupiter.MockitoExtension;
+import org.modelmapper.ModelMapper;
+
+import java.util.Optional;
+
+import static org.junit.jupiter.api.Assertions.*;
+import static org.mockito.BDDMockito.*;
+
+@ExtendWith(MockitoExtension.class)
+public class FollowServiceTest {
+
+    FollowService followService;
+
+    @Mock
+    FollowRepository followRepository;
+
+    @Mock
+    UserRepository userRepository;
+
+    @Spy
+    ModelMapper modelMapper;
+    private Long followUserId;
+    private Long userId;
+    private UserEntity userEntity;
+    private UserEntity followUserEntity;
+    private FollowEntity followEntity;
+
+    @BeforeEach
+    public void setUp() {
+        followService = new FollowServiceImpl(followRepository, userRepository, modelMapper);
+
+        followUserId = 2L;
+        userId = 1L;
+
+        followUserEntity = UserEntity.builder().id(followUserId).build();
+        userEntity = UserEntity.builder().id(userId).build();
+        followEntity = FollowEntity.builder().followUser(followUserEntity).user(userEntity).build();
+        followEntity.setId(1L);
+    }
+
+
+    @DisplayName("followUserId(팔로우 할 상대), userId(자기자신) 입력 받아 follow entity save 후 follow dto 반환")
+    @Test
+    public void followTest() {
+        given(userRepository.findById(eq(followUserId))).willReturn(Optional.ofNullable(userEntity));
+        given(followRepository.save(any(FollowEntity.class))).willReturn(followEntity);
+
+        FollowDto actual = followService.follow(followUserId, userId);
+
+        assertNotNull(actual);
+        assertEquals(followUserId, actual.getFollowUser().getId());
+    }
+
+    @DisplayName("followUserId(팔로우 할 상대), userId(자기자신) 입력 받아 없는 user의 경우 USER_NOT_FOUND Throw")
+    @Test
+    public void followFailure404Test() {
+        given(userRepository.findById(eq(followUserId))).willReturn(Optional.ofNullable(null));
+
+        try {
+            followService.follow(followUserId, userId);
+            fail();
+        } catch (ZooooException e) {
+            assertEquals(ErrorCode.USER_NOT_FOUND, e.getErrorCode());
+        } catch (Exception e) {
+            fail();
+        }
+    }
+
+    @DisplayName("followUserId(팔로우 할 상대), userId(자기자신) 입력 받아 이미 follow 한 user의 경우 ALREADY_FOLLOWED throw")
+    @Test
+    public void followFailure409AlreadyTest() {
+        given(userRepository.findById(eq(followUserId))).willReturn(Optional.ofNullable(userEntity));
+        given(followRepository.save(any(FollowEntity.class))).willReturn(followEntity);
+        followService.follow(followUserId, userId);
+        try {
+            given(followRepository.findByFollowUserIdAndUserId(eq(followUserId), eq(userId))).willReturn(followEntity);
+            followService.follow(followUserId, userId);
+            fail();
+        } catch (ZooooException e) {
+             assertEquals(ErrorCode.ALREADY_FOLLOWED_USER, e.getErrorCode());
+        } catch (Exception e) {
+            fail();
+        }
+    }
+
+    @DisplayName("followUserId(팔로우 할 상대), userId(자기자신) 입력 받아 자기 자신을 follow 하려는 경우 FOLLOWING_SELF throw")
+    @Test
+    public void followFailure409Self() {
+        try {
+            followService.follow(userId, userId);
+            fail();
+        } catch (ZooooException e) {
+            assertEquals(ErrorCode.FOLLOWING_SELF, e.getErrorCode());
+        } catch (Exception e) {
+            fail();
+        }
+    }
+}

--- a/src/test/java/com/zoooohs/instagramclone/domain/hashtag/controller/HashTagControllerTest.java
+++ b/src/test/java/com/zoooohs/instagramclone/domain/hashtag/controller/HashTagControllerTest.java
@@ -1,0 +1,69 @@
+package com.zoooohs.instagramclone.domain.hashtag.controller;
+
+import com.zoooohs.instagramclone.configuration.SecurityConfiguration;
+import com.zoooohs.instagramclone.domain.common.model.SearchModel;
+import com.zoooohs.instagramclone.domain.hashtag.dto.Search;
+import com.zoooohs.instagramclone.domain.hashtag.service.HashTagService;
+import org.hamcrest.Matchers;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.junit.jupiter.MockitoExtension;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.autoconfigure.web.servlet.AutoConfigureMockMvc;
+import org.springframework.boot.test.autoconfigure.web.servlet.WebMvcTest;
+import org.springframework.boot.test.mock.mockito.MockBean;
+import org.springframework.context.annotation.ComponentScan;
+import org.springframework.context.annotation.FilterType;
+import org.springframework.test.web.servlet.MockMvc;
+import org.springframework.test.web.servlet.request.MockMvcRequestBuilders;
+import org.springframework.test.web.servlet.result.MockMvcResultMatchers;
+
+import java.util.ArrayList;
+import java.util.List;
+
+import static org.mockito.BDDMockito.any;
+import static org.mockito.BDDMockito.given;
+
+@AutoConfigureMockMvc(addFilters = false)
+@WebMvcTest(
+        controllers = HashTagController.class,
+        excludeFilters = {
+                @ComponentScan.Filter(
+                        type = FilterType.ASSIGNABLE_TYPE,
+                        classes = SecurityConfiguration.class
+                )
+        }
+)
+@ExtendWith(MockitoExtension.class)
+public class HashTagControllerTest {
+
+    @Autowired
+    MockMvc mockMvc;
+
+    @MockBean
+    HashTagService hashTagService;
+
+    @DisplayName("GET /hash-tag, paging, keyword 입력받아 해쉬 태그 리스트 반환")
+    @Test
+    public void searchTest() throws Exception {
+        String url = "/hash-tag";
+
+        List<Search> hashTagDtos = new ArrayList<>();
+        for (int i = 0; i < 20; i++) {
+            Search hashTagDto = Search.builder().tag("hello"+i).count((long)20-i).build();
+            hashTagDtos.add(hashTagDto);
+        }
+
+        given(hashTagService.search(any(SearchModel.class))).willReturn(hashTagDtos);
+
+        mockMvc.perform(MockMvcRequestBuilders.get(url)
+                        .queryParam("keyword", "#hello")
+                        .queryParam("index", "0")
+                        .queryParam("size", "20"))
+                .andExpect(MockMvcResultMatchers.status().isOk())
+                .andExpect(MockMvcResultMatchers.jsonPath("$[0].count", Matchers.instanceOf(Integer.class)))
+                .andExpect(MockMvcResultMatchers.jsonPath("$[0].tag", Matchers.instanceOf(String.class)))
+        ;
+    }
+}

--- a/src/test/java/com/zoooohs/instagramclone/domain/hashtag/repository/HashTagRepositoryTest.java
+++ b/src/test/java/com/zoooohs/instagramclone/domain/hashtag/repository/HashTagRepositoryTest.java
@@ -1,5 +1,6 @@
 package com.zoooohs.instagramclone.domain.hashtag.repository;
 
+import com.zoooohs.instagramclone.domain.hashtag.dto.Search;
 import com.zoooohs.instagramclone.domain.hashtag.entity.HashTagEntity;
 import com.zoooohs.instagramclone.domain.post.entity.PostEntity;
 import com.zoooohs.instagramclone.domain.post.repository.PostRepository;
@@ -13,6 +14,7 @@ import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.autoconfigure.jdbc.AutoConfigureTestDatabase;
 import org.springframework.boot.test.autoconfigure.orm.jpa.DataJpaTest;
+import org.springframework.data.domain.PageRequest;
 import org.springframework.data.jpa.repository.config.EnableJpaAuditing;
 import org.springframework.security.crypto.factory.PasswordEncoderFactories;
 import org.springframework.security.crypto.password.PasswordEncoder;
@@ -138,5 +140,15 @@ public class HashTagRepositoryTest {
 
         actual = hashTagRepository.findAllById(hashTagIds);
         assertEquals(0, actual.size());
+    }
+
+    @DisplayName("keyword, pageable  받아와, hashtag 리스트 반환하는 레포지토리")
+    @Test
+    public void searchLikeTagTest() {
+        hashTagRepository.saveAll(hashTagEntities);
+
+        List<Search> actual = hashTagRepository.searchLikeTag("e", PageRequest.of(0, 20));
+
+        assertEquals(2, actual.size());
     }
 }

--- a/src/test/java/com/zoooohs/instagramclone/domain/hashtag/repository/HashTagRepositoryTest.java
+++ b/src/test/java/com/zoooohs/instagramclone/domain/hashtag/repository/HashTagRepositoryTest.java
@@ -1,0 +1,142 @@
+package com.zoooohs.instagramclone.domain.hashtag.repository;
+
+import com.zoooohs.instagramclone.domain.hashtag.entity.HashTagEntity;
+import com.zoooohs.instagramclone.domain.post.entity.PostEntity;
+import com.zoooohs.instagramclone.domain.post.repository.PostRepository;
+import com.zoooohs.instagramclone.domain.user.entity.UserEntity;
+import com.zoooohs.instagramclone.domain.user.repository.UserRepository;
+import com.zoooohs.instagramclone.exception.ErrorCode;
+import com.zoooohs.instagramclone.exception.ZooooException;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.autoconfigure.jdbc.AutoConfigureTestDatabase;
+import org.springframework.boot.test.autoconfigure.orm.jpa.DataJpaTest;
+import org.springframework.data.jpa.repository.config.EnableJpaAuditing;
+import org.springframework.security.crypto.factory.PasswordEncoderFactories;
+import org.springframework.security.crypto.password.PasswordEncoder;
+
+import javax.persistence.EntityManager;
+import java.util.Date;
+import java.util.List;
+import java.util.Set;
+import java.util.stream.Collectors;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+
+@EnableJpaAuditing
+@DataJpaTest
+@AutoConfigureTestDatabase(replace = AutoConfigureTestDatabase.Replace.NONE)
+public class HashTagRepositoryTest {
+
+    private PasswordEncoder passwordEncoder;
+    private UserEntity user;
+    private PostEntity post;
+
+    @Autowired
+    private UserRepository userRepository;
+    @Autowired
+    private PostRepository postRepository;
+    @Autowired
+    private HashTagRepository hashTagRepository;
+    private List<String> tags;
+    private Set<HashTagEntity> hashTagEntities;
+
+    @Autowired
+    EntityManager entityManager;
+
+    @BeforeEach
+    public void setUp() {
+        passwordEncoder = PasswordEncoderFactories.createDelegatingPasswordEncoder();
+        Date now = new Date();
+        String testEmail = "tt-sign-up-test-id"+now.getTime()+"@email.com";
+        String testPassword = "passwd";
+        String testName = "sign-up-test-name"+now.getTime();
+        String content = "#hello#world 123 #bye_bye_bye, #$";
+        user = new UserEntity();
+        user.setEmail(testEmail);
+        user.setPassword(passwordEncoder.encode(testPassword));
+        user.setName(testName);
+        user = this.userRepository.save(user);
+        post = PostEntity.builder().description(content).user(user).build();
+        post = this.postRepository.save(post);
+
+        tags = List.of("#hello", "#world", "#bye_bye_bye");
+        hashTagEntities = tags.stream().map(tag -> HashTagEntity.builder().post(post).tag(tag).build()).collect(Collectors.toSet());
+    }
+
+    @DisplayName("해쉬 태그, 게시글 쌍 entity save  테스트")
+    @Test
+    public void saveAllTest() {
+        List<HashTagEntity> actual = hashTagRepository.saveAll(hashTagEntities);
+
+        assertEquals(tags.size(), actual.size());
+        assertEquals(tags.size(), actual.stream().map(HashTagEntity::getTag).filter(tags::contains).count());
+    }
+
+    @DisplayName("post로 hash tag 저장 테스트")
+    @Test
+    public void saveFromPostMergeTest() {
+        post.setHashTags(hashTagEntities);
+
+        postRepository.save(post).getHashTags();
+
+        List<HashTagEntity> actual = hashTagRepository.findByPostId(post.getId());
+
+        assertEquals(tags.size(), actual.size());
+        assertEquals(tags.size(), actual.stream().map(HashTagEntity::getTag).filter(tags::contains).count());
+    }
+
+    @DisplayName("post로 hash tag 저장 테스트")
+    @Test
+    public void saveFromPostPersistTest() {
+        String content = "#hello#world 123 #bye_bye_bye, #$";
+        PostEntity post = PostEntity.builder().description(content).user(user).build();
+        hashTagEntities = tags.stream().map(tag -> HashTagEntity.builder().tag(tag).build()).collect(Collectors.toSet());
+        post.setHashTags(hashTagEntities);
+
+        postRepository.save(post).getHashTags();
+
+        List<HashTagEntity> actual = hashTagRepository.findByPostId(post.getId());
+
+        assertEquals(tags.size(), actual.size());
+        assertEquals(tags.size(), actual.stream().map(HashTagEntity::getTag).filter(tags::contains).count());
+    }
+
+    @DisplayName("postId 로  hashTagEntity 찾기")
+    @Test
+    public void findByPostIdTest() {
+        hashTagRepository.saveAll(hashTagEntities);
+
+        List<HashTagEntity> actual = hashTagRepository.findByPostId(post.getId());
+        assertEquals(tags.size(), actual.size());
+        assertEquals(tags.size(), actual.stream().map(HashTagEntity::getTag).filter(tags::contains).count());
+    }
+
+    @DisplayName("게시글 지우면 해쉬태그도 같이 제거")
+    @Test
+    public void postOrphanRemovalTest() {
+        hashTagRepository.saveAll(hashTagEntities);
+
+        List<Long> hashTagIds = hashTagEntities.stream().map(HashTagEntity::getId).collect(Collectors.toList());
+        Long postId = post.getId();
+
+        entityManager.flush();
+        entityManager.clear();
+        entityManager.detach(post);
+        for (HashTagEntity hashTagEntity: hashTagEntities) {
+            entityManager.detach(hashTagEntity);
+        }
+
+        post = postRepository.findByIdForDelete(postId).orElseThrow(() -> new ZooooException(ErrorCode.POST_NOT_FOUND));
+
+        postRepository.delete(post);
+
+        List<HashTagEntity> actual = hashTagRepository.findByPostId(postId);
+        assertEquals(0, actual.size());
+
+        actual = hashTagRepository.findAllById(hashTagIds);
+        assertEquals(0, actual.size());
+    }
+}

--- a/src/test/java/com/zoooohs/instagramclone/domain/hashtag/service/HashTagServiceTest.java
+++ b/src/test/java/com/zoooohs/instagramclone/domain/hashtag/service/HashTagServiceTest.java
@@ -1,6 +1,8 @@
 package com.zoooohs.instagramclone.domain.hashtag.service;
 
+import com.zoooohs.instagramclone.domain.common.model.SearchModel;
 import com.zoooohs.instagramclone.domain.hashtag.dto.HashTagDto;
+import com.zoooohs.instagramclone.domain.hashtag.dto.Search;
 import com.zoooohs.instagramclone.domain.hashtag.entity.HashTagEntity;
 import com.zoooohs.instagramclone.domain.hashtag.repository.HashTagRepository;
 import com.zoooohs.instagramclone.domain.post.entity.PostEntity;
@@ -12,9 +14,11 @@ import org.mockito.Mock;
 import org.mockito.Spy;
 import org.mockito.junit.jupiter.MockitoExtension;
 import org.modelmapper.ModelMapper;
+import org.springframework.data.domain.Pageable;
 
 import static org.mockito.BDDMockito.*;
 
+import java.util.ArrayList;
 import java.util.List;
 
 import static org.junit.jupiter.api.Assertions.*;
@@ -93,6 +97,28 @@ public class HashTagServiceTest {
         List<HashTagDto> actual = hashTagService.manage(content, null);
 
         assertEquals(4, actual.size());
+    }
+
+    @DisplayName("paging, keyword 받아와 hashtag 리스트 반환하는 서비스")
+    @Test
+    public void searchTest() {
+        SearchModel searchModel = new SearchModel();
+        searchModel.setKeyword("hello");
+        searchModel.setIndex(0);
+        searchModel.setSize(20);
+
+        List<Search> hashTagDtos = new ArrayList<>();
+        for (int i = 0; i < 20; i++) {
+            Search hashTagDto = Search.builder().tag("hello"+i).count((long)20-i).build();
+            hashTagDtos.add(hashTagDto);
+        }
+
+        given(hashTagRepository.searchLikeTag(any(String.class), any(Pageable.class))).willReturn(hashTagDtos);
+
+        List<Search> actual = hashTagService.search(searchModel);
+
+        assertInstanceOf(Long.class, actual.get(0).getCount());
+        assertEquals(hashTagDtos.size(), actual.size());
     }
 
 }

--- a/src/test/java/com/zoooohs/instagramclone/domain/hashtag/service/HashTagServiceTest.java
+++ b/src/test/java/com/zoooohs/instagramclone/domain/hashtag/service/HashTagServiceTest.java
@@ -1,0 +1,98 @@
+package com.zoooohs.instagramclone.domain.hashtag.service;
+
+import com.zoooohs.instagramclone.domain.hashtag.dto.HashTagDto;
+import com.zoooohs.instagramclone.domain.hashtag.entity.HashTagEntity;
+import com.zoooohs.instagramclone.domain.hashtag.repository.HashTagRepository;
+import com.zoooohs.instagramclone.domain.post.entity.PostEntity;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.Mock;
+import org.mockito.Spy;
+import org.mockito.junit.jupiter.MockitoExtension;
+import org.modelmapper.ModelMapper;
+
+import static org.mockito.BDDMockito.*;
+
+import java.util.List;
+
+import static org.junit.jupiter.api.Assertions.*;
+
+@ExtendWith(MockitoExtension.class)
+public class HashTagServiceTest {
+
+    private HashTagService hashTagService;
+    private String content;
+
+    @Mock
+    private HashTagRepository hashTagRepository;
+
+    @Spy
+    private ModelMapper modelMapper;
+
+    @BeforeEach
+    public void setUp() {
+        hashTagService = new HashTagServiceImpl(hashTagRepository, modelMapper);
+        content = "#hello#world 123 #bye_bye_bye, #$#B";
+    }
+
+    @DisplayName(" 게시글 내용기반 해쉬태그를 뽑아내기 →   List<string>")
+    @Test
+    public void extractHashTagsTest() {
+        List<String> expected = List.of("#hello", "#world", "#bye_bye_bye","#B");
+
+        List<String> actuals = hashTagService.extract(content);
+
+        assertNotNull(actuals);
+        assertEquals(expected.size(), actuals.size());
+        for (String actual: actuals) {
+           assertTrue(expected.contains(actual));
+        }
+    }
+
+    @DisplayName("게시글 내용, 포스트 id 받아서 해쉬 태그 추가 제거하는  서비스 -> 새로 저장된 해쉬 태그 반환")
+    @Test
+    public void manageHashTagTest() {
+        /**
+         * post (1L) -> #I #like #hello  3가지 해쉬 태그 있음
+         *
+         * content -> "#hello#world 123 #bye_bye_bye, #$ #B" 들어오면 기존의 I, like는 사라지고 새로운 content의 해쉬태그만 남음
+         *
+         * return -> List<HashTagDto> -> "#hello#world#bye_bye_bye#B
+         */
+        Long postId = 1L;
+
+        PostEntity post = PostEntity.builder().id(postId).build();
+
+        List<HashTagEntity> hashTagEntities = List.of(
+                HashTagEntity.builder().post(post).tag("#I").build(),
+                HashTagEntity.builder().post(post).tag("#like").build(),
+                HashTagEntity.builder().post(post).tag("#hello").build()
+        );
+
+        given(hashTagRepository.findByPostId(eq(postId))).willReturn(hashTagEntities);
+
+        List<HashTagDto> actual = hashTagService.manage(content, postId);
+
+        assertEquals(4, actual.size());
+        assertEquals(0, actual.stream().map(HashTagDto::getTag).filter(List.of("#I", "#like")::contains).count());
+    }
+
+    @DisplayName("게시글 내용, null post id 받아서 해쉬 태그 추가 제거하는  서비스 -> 새로 저장된 해쉬 태그 반환")
+    @Test
+    public void manageHashTagWithNullPostIdTest() {
+        /**
+         * post null
+         *
+         * content -> "#hello#world 123 #bye_bye_bye, #$ #B" 들어오면 기존의 I, like는 사라지고 새로운 content의 해쉬태그만 남음
+         *
+         * return -> List<HashTagDto> -> "#hello#world#bye_bye_bye#B
+         */
+
+        List<HashTagDto> actual = hashTagService.manage(content, null);
+
+        assertEquals(4, actual.size());
+    }
+
+}

--- a/src/test/java/com/zoooohs/instagramclone/domain/like/repository/PostLikeRepositoryTest.java
+++ b/src/test/java/com/zoooohs/instagramclone/domain/like/repository/PostLikeRepositoryTest.java
@@ -17,7 +17,10 @@ import org.springframework.data.jpa.repository.config.EnableJpaAuditing;
 import org.springframework.security.core.parameters.P;
 import org.springframework.security.crypto.factory.PasswordEncoderFactories;
 import org.springframework.security.crypto.password.PasswordEncoder;
+import org.springframework.transaction.annotation.Propagation;
+import org.springframework.transaction.annotation.Transactional;
 
+import javax.persistence.EntityManager;
 import java.sql.SQLException;
 import java.util.Date;
 
@@ -36,6 +39,9 @@ public class PostLikeRepositoryTest {
 
     @Autowired
     PostRepository postRepository;
+
+    @Autowired
+    EntityManager entityManager;
 
     private PasswordEncoder passwordEncoder;
     private PostEntity post;
@@ -97,5 +103,19 @@ public class PostLikeRepositoryTest {
         assertEquals(like.getId(), actual.getId());
     }
 
+    @DisplayName("PostEntity에서 likcCount query를 통해 반환")
+    @Test
+    public void likeCountTest() {
+        PostLikeEntity like = PostLikeEntity.builder().user(user).post(post).build();
+        likeRepository.save(like);
+        entityManager.flush();
+        entityManager.clear();
+
+        PostEntity postEntity = postRepository.findByIdAndUserId(post.getId(), user.getId());
+
+        Long actual = postEntity.getLikeCount();
+
+        assertEquals(1L, actual);
+    }
 
 }

--- a/src/test/java/com/zoooohs/instagramclone/domain/photo/controller/PhotoControllerTest.java
+++ b/src/test/java/com/zoooohs/instagramclone/domain/photo/controller/PhotoControllerTest.java
@@ -1,0 +1,93 @@
+package com.zoooohs.instagramclone.domain.photo.controller;
+
+import com.zoooohs.instagramclone.configuration.SecurityConfiguration;
+import com.zoooohs.instagramclone.configure.WithAuthUser;
+import com.zoooohs.instagramclone.domain.photo.dto.PhotoDto;
+import com.zoooohs.instagramclone.domain.photo.service.PhotoService;
+import com.zoooohs.instagramclone.exception.ErrorCode;
+import com.zoooohs.instagramclone.exception.ZooooException;
+import org.hamcrest.Matchers;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.junit.jupiter.MockitoExtension;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.autoconfigure.web.servlet.AutoConfigureMockMvc;
+import org.springframework.boot.test.autoconfigure.web.servlet.WebMvcTest;
+import org.springframework.boot.test.mock.mockito.MockBean;
+import org.springframework.context.annotation.ComponentScan;
+import org.springframework.context.annotation.FilterType;
+import org.springframework.http.MediaType;
+import org.springframework.mock.web.MockMultipartFile;
+import org.springframework.test.web.servlet.MockMvc;
+import org.springframework.test.web.servlet.request.MockMvcRequestBuilders;
+import org.springframework.test.web.servlet.result.MockMvcResultMatchers;
+import org.springframework.web.multipart.MultipartFile;
+
+
+import static org.mockito.BDDMockito.*;
+
+
+@AutoConfigureMockMvc(addFilters = false)
+@WebMvcTest(
+        controllers = PhotoController.class,
+        excludeFilters = {
+                @ComponentScan.Filter(
+                        type = FilterType.ASSIGNABLE_TYPE,
+                        classes = SecurityConfiguration.class
+                )
+        }
+)
+@ExtendWith(MockitoExtension.class)
+public class PhotoControllerTest {
+
+    @Autowired
+    MockMvc mockMvc;
+
+    @MockBean
+    PhotoService photoService;
+
+    @DisplayName("PATCH /user/{userId}/photo, multipart photo, jwt 입력 받아 User Info json 반환. jpg, png가 아닌경우 400, userId와 jwt가 일치하지 않는 경우 404 반환")
+    @Test
+    @WithAuthUser(email = "user1@test.test", id = 1L)
+    public void uploadProfileTest() throws Exception {
+        String url = String.format("/user/%s/photo", 1L);
+        String url404 = String.format("/user/%s/photo", 2L);
+
+        MockMultipartFile imageFile = new MockMultipartFile("photo", "original_name.jpg", MediaType.IMAGE_JPEG_VALUE, "image_content".getBytes());
+
+        PhotoDto.Photo photo = PhotoDto.Photo.builder().id(1L).path("some path").build();
+
+        given(photoService.uploadProfile(any(MultipartFile.class), eq(1L))).willReturn(photo);
+
+        mockMvc.perform(MockMvcRequestBuilders.multipart(url)
+                        .file(imageFile))
+                .andExpect(MockMvcResultMatchers.status().isOk())
+                .andExpect(MockMvcResultMatchers.jsonPath("$.path", Matchers.instanceOf(String.class)))
+                .andExpect(MockMvcResultMatchers.jsonPath("$.id", Matchers.instanceOf(Integer.class)))
+        ;
+
+        mockMvc.perform(MockMvcRequestBuilders.multipart(url404)
+                        .file(imageFile))
+                .andExpect(MockMvcResultMatchers.status().isNotFound())
+                .andExpect(MockMvcResultMatchers.jsonPath("$.code", Matchers.is(ErrorCode.USER_NOT_FOUND.name())))
+        ;
+    }
+
+    @DisplayName("PATCH /user/{userId}/photo, multipart photo, jwt 입력 받아 jpg, png가 아닌경우 400")
+    @Test
+    @WithAuthUser(email = "user1@test.test", id = 1L)
+    public void uploadProfileFailure400Test() throws Exception {
+        String url = String.format("/user/%s/photo", 1L);
+
+        MockMultipartFile nonImageFile = new MockMultipartFile("photo", "original_name.txt", MediaType.TEXT_PLAIN_VALUE, "text_content".getBytes());
+
+        given(photoService.uploadProfile(any(MultipartFile.class), eq(1L))).willThrow(new ZooooException(ErrorCode.INVALID_FILE_TYPE));
+
+        mockMvc.perform(MockMvcRequestBuilders.multipart(url)
+                        .file(nonImageFile))
+                .andExpect(MockMvcResultMatchers.status().isBadRequest())
+                .andExpect(MockMvcResultMatchers.jsonPath("$.code", Matchers.is(ErrorCode.INVALID_FILE_TYPE.name())))
+        ;
+    }
+}

--- a/src/test/java/com/zoooohs/instagramclone/domain/photo/service/PhotoServiceTest.java
+++ b/src/test/java/com/zoooohs/instagramclone/domain/photo/service/PhotoServiceTest.java
@@ -5,6 +5,10 @@ import com.zoooohs.instagramclone.domain.file.service.StorageService;
 import com.zoooohs.instagramclone.domain.photo.dto.PhotoDto;
 import com.zoooohs.instagramclone.domain.photo.entity.PhotoEntity;
 import com.zoooohs.instagramclone.domain.photo.repository.PhotoRepository;
+import com.zoooohs.instagramclone.domain.user.entity.UserEntity;
+import com.zoooohs.instagramclone.domain.user.repository.UserRepository;
+import com.zoooohs.instagramclone.exception.ErrorCode;
+import com.zoooohs.instagramclone.exception.ZooooException;
 import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.DisplayName;
@@ -16,19 +20,21 @@ import org.mockito.junit.jupiter.MockitoExtension;
 import org.modelmapper.ModelMapper;
 import org.springframework.http.MediaType;
 import org.springframework.mock.web.MockMultipartFile;
+import org.springframework.test.context.TestPropertySource;
 import org.springframework.web.multipart.MultipartFile;
 
 import java.io.File;
 import java.util.ArrayList;
 import java.util.List;
+import java.util.Optional;
 import java.util.UUID;
 
-import static org.junit.jupiter.api.Assertions.assertEquals;
-import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.junit.jupiter.api.Assertions.*;
 import static org.mockito.BDDMockito.anyList;
 import static org.mockito.BDDMockito.given;
 
 @ExtendWith(MockitoExtension.class)
+@TestPropertySource(properties = { "cloud.aws.s3.bucket=bucket" })
 public class PhotoServiceTest {
 
     PhotoService photoService;
@@ -38,16 +44,20 @@ public class PhotoServiceTest {
     @Mock
     PhotoRepository photoRepository;
 
+    @Mock
+    UserRepository userRepository;
+
     @Spy
     ModelMapper modelMapper;
 
     private List<MultipartFile> files;
     List<String> photoIds;
+    private List<PhotoEntity> photoEntities;
 
     @BeforeEach
     public void setUp() {
         storageService = new FileSystemStorageServiceImpl();
-        photoService = new PhotoServiceImpl(photoRepository, modelMapper);
+        photoService = new PhotoServiceImpl(photoRepository, userRepository, storageService, modelMapper);
         files = new ArrayList<>();
         for (int i = 0; i < 10; i++) {
             MockMultipartFile file =
@@ -56,6 +66,13 @@ public class PhotoServiceTest {
             files.add(file);
         }
         photoIds = storageService.store(files);
+        photoEntities = new ArrayList<>();
+        for (int i = 0; i < photoIds.size(); i++) {
+            PhotoEntity photoEntity = new PhotoEntity();
+            photoEntity.setPath(photoIds.get(i));
+            photoEntity.setId((long) i);
+            photoEntities.add(photoEntity);
+        }
     }
 
     @AfterEach
@@ -69,14 +86,6 @@ public class PhotoServiceTest {
     @DisplayName("path혹은 식별자를 File 관련 Entity에 저장")
     @Test
     public void saveAllTest() {
-        List<PhotoEntity> photoEntities = new ArrayList<>();
-        for (int i = 0; i < photoIds.size(); i++) {
-            PhotoEntity photoEntity = new PhotoEntity();
-            photoEntity.setPath(photoIds.get(i));
-            photoEntity.setId((long) i);
-            photoEntities.add(photoEntity);
-        }
-
         given(photoRepository.saveAll(anyList())).willReturn(photoEntities);
 
         List<PhotoDto.Photo> actual = this.photoService.saveAll(photoIds);
@@ -84,6 +93,40 @@ public class PhotoServiceTest {
         assertEquals(photoIds.size(), actual.size());
         for (PhotoDto.Photo photo: actual) {
             assertTrue(photo.getId() != null);
+        }
+    }
+
+    @DisplayName("userId, Multipartfile 받아 photo 저장, photo entity 저장, user entity에 photo 연결 후 photo 반환")
+    @Test
+    public void uploadProfileTet() {
+        MockMultipartFile photo = new MockMultipartFile("photo", "original_name.jpg", MediaType.IMAGE_JPEG_VALUE, "image_content".getBytes());
+        Long userId = 1L;
+
+        given(userRepository.findById((1L))).willReturn(Optional.ofNullable(UserEntity.builder().id(1L).build()));
+        given(photoRepository.saveAll(anyList())).willReturn(photoEntities);
+
+        PhotoDto.Photo actual = photoService.uploadProfile(photo, userId);
+
+        assertNotNull(actual);
+        assertNotNull(actual.getId());
+        assertNotNull(actual.getPath());
+
+        photoIds.add(actual.getPath()); // for tear down
+    }
+
+    @DisplayName("multipart가 jpg, png아닐 경우 INVALID_FILE_TYPE throw")
+    @Test
+    public void uploadProfileFailure400Tet() {
+        MockMultipartFile photo = new MockMultipartFile("photo", "original_name.jpg", MediaType.TEXT_PLAIN_VALUE, "image_content".getBytes());
+        Long userId = 1L;
+
+        try {
+            photoService.uploadProfile(photo, userId);
+            fail();
+        } catch (ZooooException e) {
+            assertEquals(ErrorCode.INVALID_FILE_TYPE, e.getErrorCode());
+        } catch (Exception e) {
+            fail();
         }
     }
 }

--- a/src/test/java/com/zoooohs/instagramclone/domain/post/controller/PostControllerTest.java
+++ b/src/test/java/com/zoooohs/instagramclone/domain/post/controller/PostControllerTest.java
@@ -149,6 +149,7 @@ public class PostControllerTest {
 
         mockMvc.perform(MockMvcRequestBuilders.get(url)
                         .queryParam("keyword", "#hello")
+                        .queryParam("searchKey", "HASH_TAG")
                         .queryParam("index", "0")
                         .queryParam("size", "20"))
                 .andExpect(MockMvcResultMatchers.status().isOk())

--- a/src/test/java/com/zoooohs/instagramclone/domain/post/repository/PostRepositoryTest.java
+++ b/src/test/java/com/zoooohs/instagramclone/domain/post/repository/PostRepositoryTest.java
@@ -1,12 +1,11 @@
 package com.zoooohs.instagramclone.domain.post.repository;
 
-import com.zoooohs.instagramclone.domain.post.dto.PostDto;
 import com.zoooohs.instagramclone.domain.post.entity.PostEntity;
 import com.zoooohs.instagramclone.domain.user.entity.UserEntity;
 import com.zoooohs.instagramclone.domain.user.repository.UserRepository;
-import org.aspectj.lang.annotation.After;
 import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.autoconfigure.jdbc.AutoConfigureTestDatabase;
@@ -16,12 +15,13 @@ import org.springframework.data.jpa.repository.config.EnableJpaAuditing;
 import org.springframework.security.crypto.factory.PasswordEncoderFactories;
 import org.springframework.security.crypto.password.PasswordEncoder;
 
-import static org.junit.jupiter.api.Assertions.*;
-
 import java.util.ArrayList;
 import java.util.Date;
 import java.util.List;
 import java.util.Optional;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 
 @EnableJpaAuditing
 @DataJpaTest
@@ -142,5 +142,31 @@ public class PostRepositoryTest {
         Optional<PostEntity> actual = this.postRepository.findById(post1.getId());
 
         assertTrue(actual.isEmpty());
+    }
+
+    @DisplayName("userId list로 post entity list select 하는 post repository")
+    @Test
+    public void findAllByUserIdTest() {
+        Date now = new Date();
+        String testEmail = "tt-sign-up-test-id"+now.getTime()+"@email.com";
+        String testPassword = "passwd";
+        String testName = "sign-up-test-name"+now.getTime();
+        UserEntity user2 = new UserEntity();
+        user2.setEmail(testEmail);
+        user2.setPassword(passwordEncoder.encode(testPassword));
+        user2.setName(testName);
+        this.userRepository.save(user2);
+        post1.setUser(user2);
+        post1 = this.postRepository.save(post1);
+        PostEntity post2 = PostEntity.builder().description("post2").user(user).build();
+        this.postRepository.save(post2);
+
+
+        List<PostEntity> actual = postRepository.findAllByUserId(List.of(user.getId(), user2.getId()), PageRequest.of(0, 20));
+
+        assertEquals(2, actual.size());
+        // order by desc
+        assertEquals(post1.getId(), actual.get(1).getId());
+        assertEquals(post2.getId(), actual.get(0).getId());
     }
 }

--- a/src/test/java/com/zoooohs/instagramclone/domain/post/repository/PostRepositoryTest.java
+++ b/src/test/java/com/zoooohs/instagramclone/domain/post/repository/PostRepositoryTest.java
@@ -1,6 +1,7 @@
 package com.zoooohs.instagramclone.domain.post.repository;
 
 import com.zoooohs.instagramclone.domain.post.entity.PostEntity;
+import com.zoooohs.instagramclone.domain.post.repository.PostRepository;
 import com.zoooohs.instagramclone.domain.user.entity.UserEntity;
 import com.zoooohs.instagramclone.domain.user.repository.UserRepository;
 import org.junit.jupiter.api.AfterEach;

--- a/src/test/java/com/zoooohs/instagramclone/domain/post/repository/PostRepositoryTest.java
+++ b/src/test/java/com/zoooohs/instagramclone/domain/post/repository/PostRepositoryTest.java
@@ -1,7 +1,7 @@
 package com.zoooohs.instagramclone.domain.post.repository;
 
+import com.zoooohs.instagramclone.domain.hashtag.entity.HashTagEntity;
 import com.zoooohs.instagramclone.domain.post.entity.PostEntity;
-import com.zoooohs.instagramclone.domain.post.repository.PostRepository;
 import com.zoooohs.instagramclone.domain.user.entity.UserEntity;
 import com.zoooohs.instagramclone.domain.user.repository.UserRepository;
 import org.junit.jupiter.api.AfterEach;
@@ -16,10 +16,8 @@ import org.springframework.data.jpa.repository.config.EnableJpaAuditing;
 import org.springframework.security.crypto.factory.PasswordEncoderFactories;
 import org.springframework.security.crypto.password.PasswordEncoder;
 
-import java.util.ArrayList;
-import java.util.Date;
-import java.util.List;
-import java.util.Optional;
+import java.util.*;
+import java.util.stream.Collectors;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertTrue;
@@ -169,5 +167,20 @@ public class PostRepositoryTest {
         // order by desc
         assertEquals(post1.getId(), actual.get(1).getId());
         assertEquals(post2.getId(), actual.get(0).getId());
+    }
+
+    @DisplayName("tag로 모든 게시글 찾는 레포지토리 테스트")
+    @Test
+    public void findAllByTag() {
+        List<String> tags = List.of("#hello", "#world", "#bye_bye_bye");
+        Set<HashTagEntity> hashTagEntities = tags.stream().map(tag -> HashTagEntity.builder().post(post1).tag(tag).build()).collect(Collectors.toSet());
+        post1.setHashTags(hashTagEntities);
+        post1.setDescription("#world #hello #bye_bye_bye hihi");
+        postRepository.save(post1);
+
+        List<PostEntity> actual = postRepository.findAllByTag("#hello", PageRequest.of(0, 20));
+
+        assertEquals(1, actual.size());
+        assertTrue(actual.get(0).getDescription().contains("#hello"));
     }
 }

--- a/src/test/java/com/zoooohs/instagramclone/domain/post/service/PostServiceTest.java
+++ b/src/test/java/com/zoooohs/instagramclone/domain/post/service/PostServiceTest.java
@@ -4,6 +4,7 @@ import com.zoooohs.instagramclone.domain.common.model.PageModel;
 import com.zoooohs.instagramclone.domain.file.service.StorageService;
 import com.zoooohs.instagramclone.domain.follow.entity.FollowEntity;
 import com.zoooohs.instagramclone.domain.follow.repository.FollowRepository;
+import com.zoooohs.instagramclone.domain.hashtag.service.HashTagService;
 import com.zoooohs.instagramclone.domain.like.entity.PostLikeEntity;
 import com.zoooohs.instagramclone.domain.photo.entity.PhotoEntity;
 import com.zoooohs.instagramclone.domain.post.dto.PostDto;
@@ -50,6 +51,8 @@ public class PostServiceTest {
     FollowRepository followRepository;
     @Mock
     StorageService storageService;
+    @Mock
+    HashTagService hashTagService;
 
     PostDto.Post post;
     UserDto user;
@@ -57,7 +60,7 @@ public class PostServiceTest {
     @BeforeEach
     public void setUp() {
         MockitoAnnotations.openMocks(this);
-        postService = new PostServiceImpl(postRepository, followRepository, modelMapper, storageService);
+        postService = new PostServiceImpl(postRepository, followRepository, modelMapper, storageService, hashTagService);
         user = UserDto.builder().id(1L).build();
         UserDto.Feed userFeed = this.modelMapper.map(user, UserDto.Feed.class);
         post = PostDto.Post.builder().description("some desc").user(userFeed).photos(new ArrayList<>()).build();

--- a/src/test/java/com/zoooohs/instagramclone/domain/post/service/PostServiceTest.java
+++ b/src/test/java/com/zoooohs/instagramclone/domain/post/service/PostServiceTest.java
@@ -1,6 +1,7 @@
 package com.zoooohs.instagramclone.domain.post.service;
 
 import com.zoooohs.instagramclone.domain.common.model.PageModel;
+import com.zoooohs.instagramclone.domain.common.model.SearchModel;
 import com.zoooohs.instagramclone.domain.file.service.StorageService;
 import com.zoooohs.instagramclone.domain.follow.entity.FollowEntity;
 import com.zoooohs.instagramclone.domain.follow.repository.FollowRepository;
@@ -10,8 +11,6 @@ import com.zoooohs.instagramclone.domain.photo.entity.PhotoEntity;
 import com.zoooohs.instagramclone.domain.post.dto.PostDto;
 import com.zoooohs.instagramclone.domain.post.entity.PostEntity;
 import com.zoooohs.instagramclone.domain.post.repository.PostRepository;
-import com.zoooohs.instagramclone.domain.post.service.PostService;
-import com.zoooohs.instagramclone.domain.post.service.PostServiceImpl;
 import com.zoooohs.instagramclone.domain.user.dto.UserDto;
 import com.zoooohs.instagramclone.domain.user.entity.UserEntity;
 import com.zoooohs.instagramclone.exception.ErrorCode;
@@ -105,14 +104,47 @@ public class PostServiceTest {
 
         List<FollowEntity> followEntities = new ArrayList<>();
 
+        SearchModel searchModel = new SearchModel();
+        searchModel.setIndex(0);
+        searchModel.setSize(20);
+
+
         given(followRepository.findByUserId(eq(user.getId()))).willReturn(followEntities);
         given(this.postRepository.findAllByUserId(anyList(), eq(PageRequest.of(0, 20)))).willReturn(posts.subList(0, 20));
 
-        List<PostDto.Post> actual = postService.getFeeds(user.getId(), PageModel.builder().index(0).size(20).build());
+        List<PostDto.Post> actual = postService.getFeeds(user.getId(), searchModel);
 
 
         assertTrue(20 >= actual.size());
         assertTrue(0 < actual.size());
+    }
+
+    @DisplayName("userId 자신과 팔로워들의 게시글 dto list 반환")
+    @Test
+    public void getFeedsByHashTagTest() {
+        List<PostEntity> posts = new ArrayList<>();
+        for (int i = 0; i < 30; i++) {
+            PostEntity post = new PostEntity();
+            post.setDescription("#hello desc"+i);
+            post.setUser(UserEntity.builder().id(user.getId()).build());
+            posts.add(post);
+        }
+
+        SearchModel searchModel = new SearchModel();
+        searchModel.setKeyword("#hello");
+        searchModel.setIndex(0);
+        searchModel.setSize(20);
+
+        given(postRepository.findAllByTag(eq("#hello"), eq(PageRequest.of(0, 20)))).willReturn(posts.subList(0, 20));
+
+        List<PostDto.Post> actual = postService.getFeeds(user.getId(), searchModel);
+
+
+        assertTrue(20 >= actual.size());
+        assertTrue(0 < actual.size());
+        for (int i = 0; i < actual.size(); i++) {
+            assertTrue(actual.get(i).getDescription().contains("#hello"));
+        }
     }
 
     @Test

--- a/src/test/java/com/zoooohs/instagramclone/domain/post/service/PostServiceTest.java
+++ b/src/test/java/com/zoooohs/instagramclone/domain/post/service/PostServiceTest.java
@@ -2,6 +2,9 @@ package com.zoooohs.instagramclone.domain.post.service;
 
 import com.zoooohs.instagramclone.domain.common.model.PageModel;
 import com.zoooohs.instagramclone.domain.file.service.StorageService;
+import com.zoooohs.instagramclone.domain.follow.entity.FollowEntity;
+import com.zoooohs.instagramclone.domain.follow.repository.FollowRepository;
+import com.zoooohs.instagramclone.domain.like.entity.PostLikeEntity;
 import com.zoooohs.instagramclone.domain.photo.entity.PhotoEntity;
 import com.zoooohs.instagramclone.domain.post.dto.PostDto;
 import com.zoooohs.instagramclone.domain.post.entity.PostEntity;
@@ -11,6 +14,7 @@ import com.zoooohs.instagramclone.domain.user.entity.UserEntity;
 import com.zoooohs.instagramclone.exception.ErrorCode;
 import com.zoooohs.instagramclone.exception.ZooooException;
 import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
 import org.mockito.Mock;
@@ -23,10 +27,7 @@ import org.springframework.http.MediaType;
 import org.springframework.mock.web.MockMultipartFile;
 import org.springframework.web.multipart.MultipartFile;
 
-import java.util.ArrayList;
-import java.util.List;
-import java.util.Optional;
-import java.util.UUID;
+import java.util.*;
 import java.util.stream.Collectors;
 
 import static org.junit.jupiter.api.Assertions.*;
@@ -44,6 +45,8 @@ public class PostServiceTest {
     @Mock
     PostRepository postRepository;
     @Mock
+    FollowRepository followRepository;
+    @Mock
     StorageService storageService;
 
     PostDto.Post post;
@@ -52,10 +55,10 @@ public class PostServiceTest {
     @BeforeEach
     public void setUp() {
         MockitoAnnotations.openMocks(this);
-        postService = new PostServiceImpl(postRepository, modelMapper, storageService);
+        postService = new PostServiceImpl(postRepository, followRepository, modelMapper, storageService);
         user = UserDto.builder().id(1L).build();
         UserDto.Feed userFeed = this.modelMapper.map(user, UserDto.Feed.class);
-        post = PostDto.Post.builder().description("some desc").user(userFeed).build();
+        post = PostDto.Post.builder().description("some desc").user(userFeed).photos(new ArrayList<>()).build();
     }
 
     @Test
@@ -71,7 +74,7 @@ public class PostServiceTest {
             files.add(file);
         }
         List<String> photoPaths = files.stream().map(file -> UUID.randomUUID().toString()).collect(Collectors.toList());
-        List<PhotoEntity> photos = photoPaths.stream().map(path -> PhotoEntity.builder().path(path).build()).collect(Collectors.toList());
+        Set<PhotoEntity> photos = photoPaths.stream().map(path -> PhotoEntity.builder().path(path).build()).collect(Collectors.toSet());
         postEntity.setPhotos(photos);
 
         given(storageService.store(eq(files))).willReturn(photoPaths);
@@ -82,6 +85,29 @@ public class PostServiceTest {
         assertTrue(actual.getId() != null);
         assertEquals(post.getDescription(), actual.getDescription());
         assertEquals(files.size(), actual.getPhotos().size());
+    }
+
+    @DisplayName("userId 자신과 팔로워들의 게시글 dto list 반환")
+    @Test
+    public void getFeedsTest() {
+        List<PostEntity> posts = new ArrayList<>();
+        for (int i = 0; i < 30; i++) {
+            PostEntity post = new PostEntity();
+            post.setDescription("desc"+i);
+            post.setUser(UserEntity.builder().id(user.getId()).build());
+            posts.add(post);
+        }
+
+        List<FollowEntity> followEntities = new ArrayList<>();
+
+        given(followRepository.findByUserId(eq(user.getId()))).willReturn(followEntities);
+        given(this.postRepository.findAllByUserId(anyList(), eq(PageRequest.of(0, 20)))).willReturn(posts.subList(0, 20));
+
+        List<PostDto.Post> actual = postService.getFeeds(user.getId(), PageModel.builder().index(0).size(20).build());
+
+
+        assertTrue(20 >= actual.size());
+        assertTrue(0 < actual.size());
     }
 
     @Test
@@ -115,24 +141,31 @@ public class PostServiceTest {
             PostEntity post = new PostEntity();
             post.setDescription("desc"+i);
             post.setUser(userEntity);
+            PostLikeEntity like = PostLikeEntity.builder().user(userEntity).post(post).build();
+            Set<PostLikeEntity> likes = new HashSet();
+            likes.add(like);
+            post.setLikes(likes);
+
             posts.add(post);
         }
 
         given(this.postRepository.findByUserId(eq(user.getId()), eq(PageRequest.of(0, 20)))).willReturn(posts.subList(0, 20));
 
-        List<PostDto.Post> actual = this.postService.findByUserId(user.getId(), PageModel.builder().index(0).size(20).build());
+        List<PostDto.Post> actual = this.postService.findByUserId(user.getId(), PageModel.builder().index(0).size(20).build(), user.getId());
 
         assertTrue(20 >= actual.size());
         assertTrue(0 < actual.size());
         for (PostDto.Post p: actual) {
             assertTrue(user.getId() == p.getUser().getId());
+            assertNotNull(p.getLikeCount());
+            assertNotNull(p.isLiked());
         }
     }
 
     @Test
     public void updateDescriptionTest() {
         UserDto.Feed userFeed = this.modelMapper.map(user, UserDto.Feed.class);
-        PostDto.Post post2 = PostDto.Post.builder().user(userFeed).description("another desc").build();
+        PostDto.Post post2 = PostDto.Post.builder().user(userFeed).description("another desc").photos(new ArrayList<>()).build();
 
         PostEntity postEntity1 = this.modelMapper.map(post, PostEntity.class);
         postEntity1.setId(1L);

--- a/src/test/java/com/zoooohs/instagramclone/domain/post/service/PostServiceTest.java
+++ b/src/test/java/com/zoooohs/instagramclone/domain/post/service/PostServiceTest.java
@@ -9,6 +9,8 @@ import com.zoooohs.instagramclone.domain.photo.entity.PhotoEntity;
 import com.zoooohs.instagramclone.domain.post.dto.PostDto;
 import com.zoooohs.instagramclone.domain.post.entity.PostEntity;
 import com.zoooohs.instagramclone.domain.post.repository.PostRepository;
+import com.zoooohs.instagramclone.domain.post.service.PostService;
+import com.zoooohs.instagramclone.domain.post.service.PostServiceImpl;
 import com.zoooohs.instagramclone.domain.user.dto.UserDto;
 import com.zoooohs.instagramclone.domain.user.entity.UserEntity;
 import com.zoooohs.instagramclone.exception.ErrorCode;

--- a/src/test/java/com/zoooohs/instagramclone/domain/post/service/PostServiceTest.java
+++ b/src/test/java/com/zoooohs/instagramclone/domain/post/service/PostServiceTest.java
@@ -2,6 +2,7 @@ package com.zoooohs.instagramclone.domain.post.service;
 
 import com.zoooohs.instagramclone.domain.common.model.PageModel;
 import com.zoooohs.instagramclone.domain.common.model.SearchModel;
+import com.zoooohs.instagramclone.domain.common.type.SearchKeyType;
 import com.zoooohs.instagramclone.domain.file.service.StorageService;
 import com.zoooohs.instagramclone.domain.follow.entity.FollowEntity;
 import com.zoooohs.instagramclone.domain.follow.repository.FollowRepository;
@@ -132,6 +133,7 @@ public class PostServiceTest {
 
         SearchModel searchModel = new SearchModel();
         searchModel.setKeyword("#hello");
+        searchModel.setSearchKey(SearchKeyType.HASH_TAG);
         searchModel.setIndex(0);
         searchModel.setSize(20);
 
@@ -139,12 +141,16 @@ public class PostServiceTest {
 
         List<PostDto.Post> actual = postService.getFeeds(user.getId(), searchModel);
 
+        searchModel.setSearchKey(SearchKeyType.NAME);
+        List<PostDto.Post> actualZeroSize = postService.getFeeds(user.getId(), searchModel);
+
 
         assertTrue(20 >= actual.size());
         assertTrue(0 < actual.size());
         for (int i = 0; i < actual.size(); i++) {
             assertTrue(actual.get(i).getDescription().contains("#hello"));
         }
+        assertEquals(0, actualZeroSize.size());
     }
 
     @Test

--- a/src/test/java/com/zoooohs/instagramclone/domain/user/controller/UserControllerTest.java
+++ b/src/test/java/com/zoooohs/instagramclone/domain/user/controller/UserControllerTest.java
@@ -52,7 +52,7 @@ public class UserControllerTest {
 
         List<UserDto.Info> users = new ArrayList<>();
         for (int i = 0; i < 20; i++) {
-            UserDto.Info user = UserDto.Info.builder().id((long)i).bio("bio").name("aaa").profilePhoto(new PhotoDto.Photo()).build();
+            UserDto.Info user = UserDto.Info.builder().id((long)i).bio("bio").name("aaa").photo(new PhotoDto.Photo()).build();
             users.add(user);
         }
 

--- a/src/test/java/com/zoooohs/instagramclone/domain/user/controller/UserControllerTest.java
+++ b/src/test/java/com/zoooohs/instagramclone/domain/user/controller/UserControllerTest.java
@@ -1,0 +1,85 @@
+package com.zoooohs.instagramclone.domain.user.controller;
+
+import com.zoooohs.instagramclone.configuration.SecurityConfiguration;
+import com.zoooohs.instagramclone.domain.common.model.SearchModel;
+import com.zoooohs.instagramclone.domain.photo.dto.PhotoDto;
+import com.zoooohs.instagramclone.domain.user.dto.UserDto;
+import com.zoooohs.instagramclone.domain.user.service.UserService;
+import org.hamcrest.Matchers;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.junit.jupiter.MockitoExtension;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.autoconfigure.web.servlet.AutoConfigureMockMvc;
+import org.springframework.boot.test.autoconfigure.web.servlet.WebMvcTest;
+import org.springframework.boot.test.mock.mockito.MockBean;
+import org.springframework.context.annotation.ComponentScan;
+import org.springframework.context.annotation.FilterType;
+import org.springframework.test.web.servlet.MockMvc;
+import org.springframework.test.web.servlet.request.MockMvcRequestBuilders;
+import org.springframework.test.web.servlet.result.MockMvcResultMatchers;
+
+import java.util.ArrayList;
+import java.util.List;
+
+import static org.mockito.BDDMockito.any;
+import static org.mockito.BDDMockito.given;
+
+@AutoConfigureMockMvc(addFilters = false)
+@WebMvcTest(
+        controllers = UserController.class,
+        excludeFilters = {
+                @ComponentScan.Filter(
+                        type = FilterType.ASSIGNABLE_TYPE,
+                        classes = SecurityConfiguration.class
+                )
+        }
+)
+@ExtendWith(MockitoExtension.class)
+public class UserControllerTest {
+
+    @Autowired
+    MockMvc mockMvc;
+
+    @MockBean
+    UserService userService;
+
+    @DisplayName("GET /user?keyword,seach_key,index,size 입력 받아 user list 반환")
+    @Test
+    public void searchUserTest() throws Exception {
+        String url = "/user";
+
+        List<UserDto.Info> users = new ArrayList<>();
+        for (int i = 0; i < 20; i++) {
+            UserDto.Info user = UserDto.Info.builder().id((long)i).bio("bio").name("aaa").profilePhoto(new PhotoDto.Photo()).build();
+            users.add(user);
+        }
+
+        given(userService.getUsers(any(SearchModel.class))).willReturn(users);
+
+        mockMvc.perform(MockMvcRequestBuilders.get(url)
+                        .queryParam("keyword", "aa")
+                        .queryParam("searchKey", "NAME")
+                        .queryParam("index", "0")
+                        .queryParam("size", "20"))
+                .andExpect(MockMvcResultMatchers.status().isOk())
+                .andExpect(MockMvcResultMatchers.jsonPath("$[0].name", Matchers.containsString("aa")))
+        ;
+
+    }
+    @DisplayName("GET /user?keyword,seach_key,index,size 입력 받아 user list 반환")
+    @Test
+    public void searchUserFailure400Test() throws Exception {
+        String url = "/user";
+
+        mockMvc.perform(MockMvcRequestBuilders.get(url)
+                        .queryParam("keyword", "aa")
+                        .queryParam("search_key", "nam")
+                        .queryParam("index", "0")
+                        .queryParam("size", "20"))
+                .andExpect(MockMvcResultMatchers.status().isBadRequest())
+        ;
+
+    }
+}

--- a/src/test/java/com/zoooohs/instagramclone/domain/user/repository/UserRepositoryTest.java
+++ b/src/test/java/com/zoooohs/instagramclone/domain/user/repository/UserRepositoryTest.java
@@ -3,17 +3,20 @@ package com.zoooohs.instagramclone.domain.user.repository;
 import com.zoooohs.instagramclone.domain.user.entity.UserEntity;
 import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
-import org.junit.jupiter.api.extension.ExtendWith;
-import org.mockito.junit.jupiter.MockitoExtension;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.autoconfigure.jdbc.AutoConfigureTestDatabase;
 import org.springframework.boot.test.autoconfigure.orm.jpa.DataJpaTest;
+import org.springframework.data.domain.PageRequest;
+import org.springframework.data.domain.Pageable;
 import org.springframework.data.jpa.repository.config.EnableJpaAuditing;
 import org.springframework.security.crypto.factory.PasswordEncoderFactories;
 import org.springframework.security.crypto.password.PasswordEncoder;
 
+import java.util.List;
 import java.util.Optional;
+import java.util.stream.Stream;
 
 import static org.junit.jupiter.api.Assertions.*;
 
@@ -94,5 +97,26 @@ public class UserRepositoryTest {
         assertEquals(userEntity.getEmail(), actual.get().getEmail());
         assertEquals(userEntity.getName(), actual.get().getName());
         assertTrue(nullActual.isEmpty());
+    }
+
+    @DisplayName("findByNameIgnoreCaseContaining name keyword, index, size에 만족하는 user entity 반환")
+    @Test
+    public void findByNameIgnoreCaseContainingTest() {
+        Pageable pageable = PageRequest.of(0, 20);
+
+        for (int i = 0; i < 30; i++) {
+            userEntity = UserEntity.builder()
+                    .name("a"+i).email("test@test.test"+i).password(passwordEncoder.encode("passwd")).build();
+            this.userRepository.save(userEntity);
+        }
+
+        Optional<List<UserEntity>> maybeUsers = Optional.ofNullable(userRepository.findByNameIgnoreCaseContaining("a1", pageable));
+
+        long count = maybeUsers.map(List::stream)
+                .map(actuals -> actuals.filter(actual -> actual.getName().contains("a1")))
+                .map(Stream::count)
+                .orElse((long) 0);
+
+        assertEquals(11, count);
     }
 }

--- a/src/test/java/com/zoooohs/instagramclone/domain/user/service/UserServiceTest.java
+++ b/src/test/java/com/zoooohs/instagramclone/domain/user/service/UserServiceTest.java
@@ -23,7 +23,7 @@ import java.util.List;
 import java.util.Optional;
 import java.util.stream.Stream;
 
-import static org.junit.jupiter.api.Assertions.*;
+import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.mockito.BDDMockito.*;
 
 @ExtendWith(MockitoExtension.class)
@@ -104,7 +104,11 @@ public class UserServiceTest {
 
         given(userRepository.findByNameIgnoreCaseContaining("aa", PageRequest.of(0, 20))).willReturn(users);
 
+        // 여기까지 Optional일 필요가 있나 싶긴하다
         Optional<List<UserDto.Info>> maybeUsers = Optional.ofNullable(userService.getUsers(searchModel));
+
+        searchModel.setSearchKey(SearchKeyType.HASH_TAG);
+        Optional<List<UserDto.Info>> maybeZero = Optional.ofNullable(userService.getUsers(searchModel));
 
         long count = maybeUsers.map(List::stream)
                 .map(actuals -> actuals.filter(actual -> actual.getName().contains(searchModel.getKeyword())))
@@ -112,6 +116,7 @@ public class UserServiceTest {
                 .orElse((long) 0);
 
         assertEquals(users.size(), count);
+        assertEquals(0, maybeZero.map(List::size).orElse(0));
     }
 
     private UserDto.Info makeUserDto(Long id, String name, String bio, String profilePhotoPath) {

--- a/src/test/java/com/zoooohs/instagramclone/domain/user/service/UserServiceTest.java
+++ b/src/test/java/com/zoooohs/instagramclone/domain/user/service/UserServiceTest.java
@@ -1,11 +1,14 @@
 package com.zoooohs.instagramclone.domain.user.service;
 
+import com.zoooohs.instagramclone.domain.common.model.SearchModel;
+import com.zoooohs.instagramclone.domain.common.type.SearchKeyType;
 import com.zoooohs.instagramclone.domain.photo.dto.PhotoDto;
 import com.zoooohs.instagramclone.domain.photo.entity.PhotoEntity;
 import com.zoooohs.instagramclone.domain.user.dto.UserDto;
 import com.zoooohs.instagramclone.domain.user.entity.UserEntity;
 import com.zoooohs.instagramclone.domain.user.repository.UserRepository;
 import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
 import org.mockito.Mock;
@@ -13,8 +16,13 @@ import org.mockito.MockitoAnnotations;
 import org.mockito.Spy;
 import org.mockito.junit.jupiter.MockitoExtension;
 import org.modelmapper.ModelMapper;
+import org.springframework.data.domain.PageRequest;
+import org.springframework.data.domain.Pageable;
 
+import java.util.ArrayList;
+import java.util.List;
 import java.util.Optional;
+import java.util.stream.Stream;
 
 import static org.junit.jupiter.api.Assertions.*;
 import static org.mockito.BDDMockito.*;
@@ -82,6 +90,29 @@ public class UserServiceTest {
         UserDto.Info actual = userService.updateBio(changedBio, userDto);
 
         assertEquals(changedBio, actual.getBio());
+    }
+
+    @DisplayName("keyword, search_key=name, index, size 입력받아 keyword와 유사한 이름을 가진 user list 반환")
+    @Test
+    public void getUsersTest() {
+        SearchModel searchModel = new SearchModel(0, 20, "aa", SearchKeyType.NAME);
+
+        List<UserEntity> users = new ArrayList<>();
+        for (int i = 0; i < 20; i++) {
+            UserEntity user = UserEntity.builder().id((long)i).name("aaa").build();
+            users.add(user);
+        }
+
+        given(userRepository.findByNameIgnoreCaseContaining("aa", PageRequest.of(0, 20))).willReturn(users);
+
+        Optional<List<UserDto.Info>> maybeUsers = Optional.ofNullable(userService.getUsers(searchModel));
+
+        long count = maybeUsers.map(List::stream)
+                .map(actuals -> actuals.filter(actual -> actual.getName().contains(searchModel.getKeyword())))
+                .map(Stream::count)
+                .orElse((long) 0);
+
+        assertEquals(users.size(), count);
     }
 
     private UserDto.Info makeUserDto(Long id, String name, String bio, String profilePhotoPath) {

--- a/src/test/java/com/zoooohs/instagramclone/domain/user/service/UserServiceTest.java
+++ b/src/test/java/com/zoooohs/instagramclone/domain/user/service/UserServiceTest.java
@@ -17,7 +17,6 @@ import org.mockito.Spy;
 import org.mockito.junit.jupiter.MockitoExtension;
 import org.modelmapper.ModelMapper;
 import org.springframework.data.domain.PageRequest;
-import org.springframework.data.domain.Pageable;
 
 import java.util.ArrayList;
 import java.util.List;
@@ -57,7 +56,7 @@ public class UserServiceTest {
         assertEquals(id, actual.getId());
         assertEquals(name, actual.getName());
         assertEquals(bio, actual.getBio());
-        assertEquals(profilePhotoPath, actual.getProfilePhoto().getPath());
+        assertEquals(profilePhotoPath, actual.getPhoto().getPath());
     }
 
     private UserEntity makeUserEntity(Long id, String name, String bio, String profilePhotoPath) {
@@ -68,7 +67,7 @@ public class UserServiceTest {
         userEntity.setId(id);
         userEntity.setName(name);
         userEntity.setBio(bio);
-        userEntity.setProfilePhoto(photoEntity);
+        userEntity.setPhoto(photoEntity);
         return userEntity;
     }
 
@@ -122,7 +121,7 @@ public class UserServiceTest {
         userDto.setName(name);
         PhotoDto.Photo photoDto = new PhotoDto.Photo();
         photoDto.setPath(profilePhotoPath);
-        userDto.setProfilePhoto(photoDto);
+        userDto.setPhoto(photoDto);
         return userDto;
     }
 }

--- a/src/test/resources/application.yaml
+++ b/src/test/resources/application.yaml
@@ -24,5 +24,13 @@ logging:
         org:
           hibernate: info
 
-storage:
-  filesystem: ${STORAGE_FS}
+instagram-clone:
+  storage:
+    filesystem: ${STORAGE_FS}
+  jwt:
+    access-token:
+      key: ${ACCESS_TOKEN_KEY:"access"}
+      valid-time: ${ACCESS_TOKEN_VALID_TIME:86400000} # default: 1 day
+    refresh-token:
+      key: ${REFRESH_TOKEN_KEY:"refresh"}
+      valid-time: ${REFRESH_TOKEN_VALID_TIME:432000000} # default: 5 days

--- a/src/test/resources/application.yaml
+++ b/src/test/resources/application.yaml
@@ -15,6 +15,8 @@ spring:
     database: mysql
     hibernate:
       ddl-auto: update
+  jackson:
+    property-naming-strategy: SNAKE_CASE
 
 
 logging:


### PR DESCRIPTION
# 추가된 기능

- 팔로우, 언팔로우 기능
    - 게시글 피드를 볼때 팔로잉 유저와 자신의 게시글만 나오도록 변경
- 검색
    - 유저 이름 검색
    - 해쉬태그 검색
        - 비슷한 단어의 해쉬태그 리스트를 반환하며, 해당 해쉬태그를 사용한 게시글 개수 또한 명시
- 댓글, 게시글 리스트 리팩토링
    - 좋아요 기능이 추가되면서, 댓글과 게시글을 받아올 때 좋아요 개수 및 현재 내가 좋아요를 눌렀는지에 대한 정보가 같이 반환 됨
- 해쉬태그
    - 게시글을 작성, 수정할 때 해쉬태그를 입력하면 시스템에 해당 게시글과 해쉬태그가 매핑되어 저장됨
    - 앞서 언급한 해쉬태그 검색기능에 사용되어, 해당 해쉬태그를 사용한 게시글 리스트 반환 및 게시글 리스트 조회 등에 사용됨

# Open API UI 연동

- SERVER_URL/swagger-ui/index.html 에 접근하면 API 정보를 조회 할 수 있음

# Future Work?

- 프로젝트 정리 문서 작성
- Frontend 프로젝트를 시작한다면, 본 프로젝트의 백엔드를 사용하는 인스타그램 클론 FE를 진행할 예정
- 도커, k8s, 클라우드 연동 관련 프로젝트