### PR TITLE
1.0.1

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # Instagram Clone Project (Backend)
 
-![Generic badge](https://img.shields.io/badge/version-1.0.0-green.svg)
+![Generic badge](https://img.shields.io/badge/version-1.0.1-green.svg)
 
 ## 목차
 
@@ -85,6 +85,10 @@ Spring boot 기반 프로젝트로 REST API 서버 구현 및 TDD 실습
     - database 사용자 ID
   - DB_PASSWORD
     - database 사용자 PASSWORD
+  - MAIL_USERNAME
+    - 회원 인증 메일 전송을 위한 Gmail 계정 ID
+  - MAIL_PASSWORD
+    - 회원 인증 메일 전송을 위한 Gmail 계정 비밀 번호
 - 선택 입력
   - ACCESS_TOKEN_VALID_TIME
     - access token 만료 시간
@@ -108,10 +112,11 @@ cd instagram-clone-be
 ```bash
 docker run --name instagram-clone -e DB_URL=localhost ... \ #환경 변수 설정 ... 
 	-p 8080:8080 \	
-	dogfooter/instagram-clone-be:1.0.0
+	dogfooter/instagram-clone-be:1.0.1
 ```
 
 ## 변경사항 및 TODO
+- [2022/03/02 (1.0.1 릴리즈)](https://dogfooter219.notion.site/1-0-1-91a10bbc10e741fc9f57c602d47a4e7d)
 - [2022/02/21 (1.0.0 릴리즈)](https://dogfooter219.notion.site/1-0-0-e4307c1f5b1c4b5baf0d9754dc442284)
 - [2022/02/12](https://dogfooter219.notion.site/2022-02-3-3c0bd58d436a462b94880dcf3a366e33)
 - [2022/02/08](https://dogfooter219.notion.site/2022-02-2-b66133f5680a4094bba04662b2975ad8)

--- a/build.gradle
+++ b/build.gradle
@@ -5,7 +5,7 @@ plugins {
 }
 
 group = 'com.zoooohs'
-version = '1.0.0'
+version = '1.0.1'
 sourceCompatibility = '11'
 
 configurations {

--- a/build.gradle
+++ b/build.gradle
@@ -37,6 +37,9 @@ dependencies {
 	testImplementation 'io.findify:s3mock_2.13:0.2.6'
 	implementation 'org.springdoc:springdoc-openapi-ui:1.6.6'
 	implementation 'org.springdoc:springdoc-openapi-security:1.6.6'
+	implementation 'org.springframework:spring-context-support:5.3.16'
+	implementation 'com.sun.mail:javax.mail:1.6.2'
+	testImplementation 'com.icegreen:greenmail:1.6.6'
 }
 
 test {

--- a/src/main/java/com/zoooohs/instagramclone/configuration/MailSenderConfiguration.java
+++ b/src/main/java/com/zoooohs/instagramclone/configuration/MailSenderConfiguration.java
@@ -1,0 +1,36 @@
+package com.zoooohs.instagramclone.configuration;
+
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.mail.javamail.JavaMailSender;
+import org.springframework.mail.javamail.JavaMailSenderImpl;
+
+import java.util.Properties;
+
+@Configuration
+public class MailSenderConfiguration {
+
+    @Bean
+    public JavaMailSender getMailSender(
+            @Value("${instagram-clone.mail.username}") String username,
+            @Value("${instagram-clone.mail.password}") String password
+    ) {
+        // TODO: gmail 말고 다양한 벤더 오픈
+        Properties properties = new Properties();
+        properties.put("mail.smtp.auth", "true");
+        properties.put("mail.transport.protocol", "smtp");
+        properties.put("mail.smtp.starttls.enable", "true");
+        properties.put("mail.debug", "false");
+
+        JavaMailSenderImpl mailSender = new JavaMailSenderImpl();
+        mailSender.setHost("smtp.gmail.com");
+        mailSender.setPort(587);
+        mailSender.setUsername(username);
+        mailSender.setPassword(password);
+        mailSender.setDefaultEncoding("UTF-8");
+        mailSender.setJavaMailProperties(properties);
+
+        return mailSender;
+    }
+}

--- a/src/main/java/com/zoooohs/instagramclone/domain/auth/controller/AuthController.java
+++ b/src/main/java/com/zoooohs/instagramclone/domain/auth/controller/AuthController.java
@@ -1,8 +1,8 @@
 package com.zoooohs.instagramclone.domain.auth.controller;
 
 import com.zoooohs.instagramclone.domain.auth.dto.AuthDto;
-import com.zoooohs.instagramclone.domain.common.model.SearchModel;
 import com.zoooohs.instagramclone.domain.auth.service.AuthService;
+import com.zoooohs.instagramclone.domain.service.MailService;
 import com.zoooohs.instagramclone.exception.ZooooExceptionResponse;
 import io.swagger.v3.oas.annotations.Operation;
 import io.swagger.v3.oas.annotations.media.Content;
@@ -10,15 +10,19 @@ import io.swagger.v3.oas.annotations.media.Schema;
 import io.swagger.v3.oas.annotations.responses.ApiResponse;
 import io.swagger.v3.oas.annotations.responses.ApiResponses;
 import lombok.RequiredArgsConstructor;
+import org.springframework.transaction.annotation.Transactional;
 import org.springframework.web.bind.annotation.*;
 
 import javax.validation.Valid;
+import java.net.URLEncoder;
+import java.nio.charset.StandardCharsets;
 
 // TODO: Auth Server 를 따로 두어서 MSA 구성?
 @RequiredArgsConstructor
 @RestController
 public class AuthController {
     private final AuthService authService;
+    private final MailService mailService;
 
     @Operation(summary = "회원 가입", description = "email, name, password 를 입력 받아 새로운 회원 생성")
     @ApiResponses(value = {
@@ -32,8 +36,16 @@ public class AuthController {
             ),
     })
     @PostMapping("/auth/sign-up")
-    public AuthDto.Token signUp(@RequestBody @Valid AuthDto.SignUp signUp) {
-        return this.authService.signUp(signUp);
+    @Transactional
+    public String signUp(@RequestBody @Valid AuthDto.SignUp signUp, @RequestHeader("origin") String origin) {
+        String verificationCode = this.authService.signUp(signUp);
+
+        final String subject = "[ZOOOO-HS INSTAGRAM CLONE] Sign-Up Email Verification";
+        final String email = URLEncoder.encode(signUp.getEmail(), StandardCharsets.UTF_8);
+        final String token = URLEncoder.encode(verificationCode, StandardCharsets.UTF_8);
+        final String text = String.format("verification link : %s/auth/verification?email=%s&token=%s", origin, email, token);
+        mailService.send(signUp.getEmail(), subject, text);
+        return "OK";
     }
 
     @Operation(summary = "로그인", description = "email, password 입력 받아 로그인")
@@ -41,6 +53,10 @@ public class AuthController {
             @ApiResponse(
                     responseCode = "200", description = "로그인 완료 및 토큰 발급",
                     content = { @Content(mediaType = "application/json", schema = @Schema(implementation = AuthDto.Token.class)) }
+            ),
+            @ApiResponse(
+                    responseCode = "401", description = "미인증 회원",
+                    content = { @Content(mediaType = "application/json", schema = @Schema(implementation = ZooooExceptionResponse.class)) }
             ),
             @ApiResponse(
                     responseCode = "404", description = "로그인 정보 오류",
@@ -90,5 +106,21 @@ public class AuthController {
     @GetMapping("/auth/email")
     public Boolean checkEmail(@RequestParam("keyword") String email) {
         return this.authService.checkDuplicatedEmail(email);
+    }
+
+    @Operation(summary = "email 인증 요청", description = "메일로 전달된 인증 링크 핸들 API")
+    @ApiResponses(value = {
+            @ApiResponse(
+                    responseCode = "200", description = "인증 완료",
+                    content = { @Content(mediaType = "application/json", schema = @Schema(implementation = Boolean.class)) }
+            ),
+            @ApiResponse(
+                    responseCode = "404", description = "요청한 인증 정보 관련된 회원 찾을 수 없음",
+                    content = { @Content(mediaType = "application/json", schema = @Schema(implementation = ZooooExceptionResponse.class)) }
+            ),
+    })
+    @GetMapping("/auth/verification")
+    public Boolean verification(@RequestParam("email") String email, @RequestParam("token") String token) {
+        return this.authService.verification(email, token);
     }
 }

--- a/src/main/java/com/zoooohs/instagramclone/domain/auth/controller/AuthController.java
+++ b/src/main/java/com/zoooohs/instagramclone/domain/auth/controller/AuthController.java
@@ -2,7 +2,7 @@ package com.zoooohs.instagramclone.domain.auth.controller;
 
 import com.zoooohs.instagramclone.domain.auth.dto.AuthDto;
 import com.zoooohs.instagramclone.domain.auth.service.AuthService;
-import com.zoooohs.instagramclone.domain.service.MailService;
+import com.zoooohs.instagramclone.domain.mail.service.MailService;
 import com.zoooohs.instagramclone.exception.ZooooExceptionResponse;
 import io.swagger.v3.oas.annotations.Operation;
 import io.swagger.v3.oas.annotations.media.Content;

--- a/src/main/java/com/zoooohs/instagramclone/domain/auth/controller/AuthController.java
+++ b/src/main/java/com/zoooohs/instagramclone/domain/auth/controller/AuthController.java
@@ -118,6 +118,10 @@ public class AuthController {
                     responseCode = "404", description = "요청한 인증 정보 관련된 회원 찾을 수 없음",
                     content = { @Content(mediaType = "application/json", schema = @Schema(implementation = ZooooExceptionResponse.class)) }
             ),
+            @ApiResponse(
+                    responseCode = "409", description = "이미 검증됨",
+                    content = { @Content(mediaType = "application/json", schema = @Schema(implementation = ZooooExceptionResponse.class)) }
+            ),
     })
     @GetMapping("/auth/verification")
     public Boolean verification(@RequestParam("email") String email, @RequestParam("token") String token) {

--- a/src/main/java/com/zoooohs/instagramclone/domain/auth/dto/AuthDto.java
+++ b/src/main/java/com/zoooohs/instagramclone/domain/auth/dto/AuthDto.java
@@ -34,8 +34,10 @@ public class AuthDto {
     }
 
     @Schema(name = "AuthDto.SignIn")
-    @Data
+    @Getter
+    @Setter
     @NoArgsConstructor
+    @EqualsAndHashCode
     public static class SignIn {
         @NotNull
         @Email

--- a/src/main/java/com/zoooohs/instagramclone/domain/auth/service/AuthService.java
+++ b/src/main/java/com/zoooohs/instagramclone/domain/auth/service/AuthService.java
@@ -3,7 +3,7 @@ package com.zoooohs.instagramclone.domain.auth.service;
 import com.zoooohs.instagramclone.domain.auth.dto.AuthDto;
 
 public interface AuthService {
-    AuthDto.Token signUp(AuthDto.SignUp signUp);
+    String signUp(AuthDto.SignUp signUp);
 
     AuthDto.Token signIn(AuthDto.SignIn signIn);
 
@@ -12,4 +12,6 @@ public interface AuthService {
     boolean checkDuplicatedEmail(String email);
 
     boolean checkDuplicatedName(String name);
+
+    Boolean verification(String email, String token);
 }

--- a/src/main/java/com/zoooohs/instagramclone/domain/auth/service/AuthServiceImpl.java
+++ b/src/main/java/com/zoooohs/instagramclone/domain/auth/service/AuthServiceImpl.java
@@ -84,13 +84,15 @@ public class AuthServiceImpl implements AuthService {
 
     @Override
     public Boolean verification(String email, String token) {
-        UserEntity user = userRepository.findByEmail(email).orElseThrow(() -> new ZooooException(ErrorCode.USER_NOT_FOUND));
-        if (passwordEncoder.matches(user.getEmail()+user.getName(), token)) {
-            user.setStatus(AccountStatusType.VERIFIED);
-            userRepository.save(user);
-            return true;
+        UserEntity user = userRepository.findByEmail(email)
+                .filter(userEntity -> passwordEncoder.matches(userEntity.getEmail()+userEntity.getName(), token))
+                .orElseThrow(() -> new ZooooException(ErrorCode.USER_NOT_FOUND));
+        if (user.getStatus().equals(AccountStatusType.VERIFIED)) {
+            throw new ZooooException(ErrorCode.ALREADY_VERIFIED);
         }
-        throw new ZooooException(ErrorCode.USER_NOT_FOUND);
+        user.setStatus(AccountStatusType.VERIFIED);
+        userRepository.save(user);
+        return true;
     }
 
 

--- a/src/main/java/com/zoooohs/instagramclone/domain/auth/service/AuthServiceImpl.java
+++ b/src/main/java/com/zoooohs/instagramclone/domain/auth/service/AuthServiceImpl.java
@@ -4,6 +4,7 @@ import com.zoooohs.instagramclone.configuration.JwtTokenProvider;
 import com.zoooohs.instagramclone.domain.auth.dto.AuthDto;
 import com.zoooohs.instagramclone.domain.auth.entity.RefreshTokenEntity;
 import com.zoooohs.instagramclone.domain.auth.repository.RefreshTokenRepository;
+import com.zoooohs.instagramclone.domain.common.type.AccountStatusType;
 import com.zoooohs.instagramclone.domain.user.entity.UserEntity;
 import com.zoooohs.instagramclone.domain.user.repository.UserRepository;
 import com.zoooohs.instagramclone.exception.ErrorCode;
@@ -28,7 +29,7 @@ public class AuthServiceImpl implements AuthService {
 
     @Override
     @Transactional
-    public AuthDto.Token signUp(AuthDto.SignUp signUp) {
+    public String signUp(AuthDto.SignUp signUp) {
         Optional<UserEntity> duplicated = this.userRepository.findByEmailAndName(signUp.getEmail(), signUp.getName());
         if (duplicated.isPresent()) {
             throw new ZooooException(ErrorCode.SIGN_UP_DUPLICATED_EMAIL_OR_NAME);
@@ -36,15 +37,18 @@ public class AuthServiceImpl implements AuthService {
         UserEntity user = this.modelMapper.map(signUp, UserEntity.class);
         user.setPassword(passwordEncoder.encode(user.getPassword()));
         this.userRepository.save(user).getId();
-        return generateNewToken(user.getUsername());
+        // TODO: verification code 만드는 방법 다시 조사하기
+        return passwordEncoder.encode(user.getEmail()+user.getName());
     }
 
     @Override
     @Transactional
     public AuthDto.Token signIn(AuthDto.SignIn signIn) {
-        UserEntity user = this.userRepository.findByEmail(signIn.getEmail()).orElseThrow(() -> new ZooooException(ErrorCode.LOGIN_WRONG_INFO));
-        if (!passwordEncoder.matches(signIn.getPassword(), user.getPassword())) {
-            throw new ZooooException(ErrorCode.LOGIN_WRONG_INFO);
+        UserEntity user = this.userRepository.findByEmail(signIn.getEmail())
+                .filter(userEntity -> passwordEncoder.matches(signIn.getPassword(), userEntity.getPassword()))
+                .orElseThrow(() -> new ZooooException(ErrorCode.LOGIN_WRONG_INFO));
+        if (user.getStatus().equals(AccountStatusType.WAITING)) {
+            throw new ZooooException(ErrorCode.USER_NOT_VERIFIED);
         }
         return generateNewToken(user.getUsername());
     }
@@ -77,6 +81,18 @@ public class AuthServiceImpl implements AuthService {
         UserEntity user = this.userRepository.findByName(name).orElse(null);
         return user != null;
     }
+
+    @Override
+    public Boolean verification(String email, String token) {
+        UserEntity user = userRepository.findByEmail(email).orElseThrow(() -> new ZooooException(ErrorCode.USER_NOT_FOUND));
+        if (passwordEncoder.matches(user.getEmail()+user.getName(), token)) {
+            user.setStatus(AccountStatusType.VERIFIED);
+            userRepository.save(user);
+            return true;
+        }
+        throw new ZooooException(ErrorCode.USER_NOT_FOUND);
+    }
+
 
     @Transactional
     private AuthDto.Token generateNewToken(String userName) {

--- a/src/main/java/com/zoooohs/instagramclone/domain/comment/controller/CommentController.java
+++ b/src/main/java/com/zoooohs/instagramclone/domain/comment/controller/CommentController.java
@@ -89,7 +89,7 @@ public class CommentController {
         return commentService.getCommentCommentList(commentId, pageModel, userDto.getId());
     }
 
-    @Operation(summary = "게시글 댓글 수정", description = "게시글 댓글의 내용을 수정한다.")
+    @Operation(summary = "댓글 수정", description = "댓글의 내용을 수정한다.")
     @ApiResponses(value = {
             @ApiResponse(
                     responseCode = "200", description = "수정 성공. 수정 결과 반환",
@@ -105,7 +105,7 @@ public class CommentController {
         return commentService.updateComment(commentId, commentDto, userDto);
     }
 
-    @Operation(summary = "게시글 댓글 삭제", description = "게시글 댓글을 삭제한다.")
+    @Operation(summary = "댓글 삭제", description = "댓글을 삭제한다.")
     @ApiResponses(value = {
             @ApiResponse(
                     responseCode = "200", description = "삭제 성공. 삭제된 댓글 ID 반환",

--- a/src/main/java/com/zoooohs/instagramclone/domain/comment/controller/CommentController.java
+++ b/src/main/java/com/zoooohs/instagramclone/domain/comment/controller/CommentController.java
@@ -3,6 +3,7 @@ package com.zoooohs.instagramclone.domain.comment.controller;
 import com.zoooohs.instagramclone.domain.comment.dto.CommentDto;
 import com.zoooohs.instagramclone.domain.comment.service.CommentService;
 import com.zoooohs.instagramclone.domain.common.model.PageModel;
+import com.zoooohs.instagramclone.domain.common.model.SearchModel;
 import com.zoooohs.instagramclone.domain.user.dto.UserDto;
 import com.zoooohs.instagramclone.exception.ZooooExceptionResponse;
 import io.swagger.v3.oas.annotations.Operation;
@@ -69,8 +70,8 @@ public class CommentController {
             ),
     })
     @GetMapping("/post/{postId}/comment")
-    public List<CommentDto> getPostCommentList(@PathVariable Long postId, @ModelAttribute @NotNull PageModel pageModel, @AuthenticationPrincipal UserDto userDto) {
-        return commentService.getPostCommentList(postId, pageModel, userDto.getId());
+    public List<CommentDto> getPostCommentList(@PathVariable Long postId, @ModelAttribute @NotNull SearchModel searchModel, @AuthenticationPrincipal UserDto userDto) {
+        return commentService.getPostCommentList(postId, searchModel, userDto.getId());
     }
 
     @Operation(summary = "대댓글 조회", description = "대댓글 리스트를 불러온다.")

--- a/src/main/java/com/zoooohs/instagramclone/domain/comment/controller/CommentController.java
+++ b/src/main/java/com/zoooohs/instagramclone/domain/comment/controller/CommentController.java
@@ -37,8 +37,24 @@ public class CommentController {
             ),
     })
     @PostMapping("/post/{postId}/comment")
-    public CommentDto create(@RequestBody @Valid CommentDto commentDto, @PathVariable Long postId, @AuthenticationPrincipal UserDto userDto) {
-        return commentService.create(commentDto, postId, userDto);
+    public CommentDto createPostComment(@RequestBody @Valid CommentDto commentDto, @PathVariable Long postId, @AuthenticationPrincipal UserDto userDto) {
+        return commentService.createPostComment(commentDto, postId, userDto);
+    }
+
+    @Operation(summary = "대댓글 작성", description = "대댓글을 작성한다.")
+    @ApiResponses(value = {
+            @ApiResponse(
+                    responseCode = "200", description = "대댓글 작성 성공. 작성 결과 반환",
+                    content = { @Content(mediaType = "application/json", schema = @Schema(implementation = CommentDto.class)) }
+            ),
+            @ApiResponse(
+                    responseCode = "404", description = "원댓글이 존재하지 않음",
+                    content = { @Content(mediaType = "application/json", schema = @Schema(implementation = ZooooExceptionResponse.class)) }
+            ),
+    })
+    @PostMapping("/comment/{commentId}/comment")
+    public CommentDto createCommentComment(@RequestBody @Valid CommentDto commentDto, @PathVariable Long commentId, @AuthenticationPrincipal UserDto userDto) {
+        return commentService.createCommentComment(commentDto, commentId, userDto);
     }
 
     @Operation(summary = "게시글 댓글 조회", description = "게시글 댓글을 리스트를 불러온다.")

--- a/src/main/java/com/zoooohs/instagramclone/domain/comment/controller/CommentController.java
+++ b/src/main/java/com/zoooohs/instagramclone/domain/comment/controller/CommentController.java
@@ -73,6 +73,22 @@ public class CommentController {
         return commentService.getPostCommentList(postId, pageModel, userDto.getId());
     }
 
+    @Operation(summary = "대댓글 조회", description = "대댓글 리스트를 불러온다.")
+    @ApiResponses(value = {
+            @ApiResponse(
+                    responseCode = "200", description = "조회 성공. 댓글 리스트 반환",
+                    content = { @Content(mediaType = "application/json", array = @ArraySchema(schema = @Schema(implementation = CommentDto.class))) }
+            ),
+            @ApiResponse(
+                    responseCode = "404", description = "게시글이 존재하지 않음",
+                    content = { @Content(mediaType = "application/json", schema = @Schema(implementation = ZooooExceptionResponse.class)) }
+            ),
+    })
+    @GetMapping("/comment/{commentId}/comment")
+    public List<CommentDto> getCommentCommentList(@PathVariable Long commentId, @ModelAttribute @NotNull PageModel pageModel, @AuthenticationPrincipal UserDto userDto) {
+        return commentService.getCommentCommentList(commentId, pageModel, userDto.getId());
+    }
+
     @Operation(summary = "게시글 댓글 수정", description = "게시글 댓글의 내용을 수정한다.")
     @ApiResponses(value = {
             @ApiResponse(

--- a/src/main/java/com/zoooohs/instagramclone/domain/comment/dto/CommentDto.java
+++ b/src/main/java/com/zoooohs/instagramclone/domain/comment/dto/CommentDto.java
@@ -28,13 +28,16 @@ public class CommentDto {
     @Schema(name = "liked", description = "내가 좋아요를 눌렀는지 여부")
     private Boolean isLiked;
 
+    @Schema(description = "대댓글 개수")
+    private Long commentCount;
 
     @Builder
-    public CommentDto(Long id, String content, UserDto.Feed user, Long likeCount, Boolean isLiked) {
+    public CommentDto(Long id, String content, UserDto.Feed user, Long likeCount, Boolean isLiked, Long commentCount) {
         this.id = id;
         this.content = content;
         this.user = user;
         this.likeCount = likeCount;
         this.isLiked = isLiked;
+        this.commentCount = commentCount;
     }
 }

--- a/src/main/java/com/zoooohs/instagramclone/domain/comment/entity/CommentCommentEntity.java
+++ b/src/main/java/com/zoooohs/instagramclone/domain/comment/entity/CommentCommentEntity.java
@@ -24,4 +24,9 @@ public class CommentCommentEntity extends CommentEntity {
         super(content, user);
         this.comment = comment;
     }
+
+    public void setComment(CommentEntity comment) {
+        this.comment = comment;
+        comment.getComments().add(this);
+    }
 }

--- a/src/main/java/com/zoooohs/instagramclone/domain/comment/entity/CommentCommentEntity.java
+++ b/src/main/java/com/zoooohs/instagramclone/domain/comment/entity/CommentCommentEntity.java
@@ -1,0 +1,27 @@
+package com.zoooohs.instagramclone.domain.comment.entity;
+
+import com.zoooohs.instagramclone.domain.user.entity.UserEntity;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import lombok.Setter;
+
+import javax.persistence.*;
+
+
+@Getter
+@Setter
+@NoArgsConstructor
+@Entity(name = "comment_comment")
+@DiscriminatorValue("comment_comment")
+public class CommentCommentEntity extends CommentEntity {
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "comment_id", nullable = false)
+    private CommentEntity comment;
+
+    @Builder
+    public CommentCommentEntity(String content, UserEntity user, CommentEntity comment) {
+        super(content, user);
+        this.comment = comment;
+    }
+}

--- a/src/main/java/com/zoooohs/instagramclone/domain/comment/entity/CommentEntity.java
+++ b/src/main/java/com/zoooohs/instagramclone/domain/comment/entity/CommentEntity.java
@@ -2,9 +2,7 @@ package com.zoooohs.instagramclone.domain.comment.entity;
 
 import com.zoooohs.instagramclone.domain.common.entity.BaseEntity;
 import com.zoooohs.instagramclone.domain.like.entity.CommentLikeEntity;
-import com.zoooohs.instagramclone.domain.post.entity.PostEntity;
 import com.zoooohs.instagramclone.domain.user.entity.UserEntity;
-import lombok.Builder;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
 import lombok.Setter;
@@ -18,19 +16,17 @@ import java.util.Set;
 @Setter
 @NoArgsConstructor
 @Entity(name = "comment")
+@Inheritance(strategy = InheritanceType.JOINED)
+@DiscriminatorColumn(name = "commentType")
 @NamedEntityGraphs({
         @NamedEntityGraph(name = "comment-user", attributeNodes = {
                 @NamedAttributeNode(value = "user"),
                 @NamedAttributeNode(value = "likes"),
         }),
 })
-public class CommentEntity extends BaseEntity {
+public abstract class CommentEntity extends BaseEntity {
     @Column(name = "content")
     private String content;
-
-    @ManyToOne(fetch = FetchType.LAZY)
-    @JoinColumn(name = "post_id", nullable = false)
-    private PostEntity post;
 
     @ManyToOne(fetch = FetchType.LAZY)
     @JoinColumn(name = "user_id", nullable = false)
@@ -43,10 +39,8 @@ public class CommentEntity extends BaseEntity {
         return (long) likes.size();
     }
 
-    @Builder
-    public CommentEntity(String content, PostEntity post, UserEntity user) {
+    public CommentEntity(String content, UserEntity user) {
         this.content = content;
-        this.post = post;
         this.user = user;
     }
 }

--- a/src/main/java/com/zoooohs/instagramclone/domain/comment/entity/CommentEntity.java
+++ b/src/main/java/com/zoooohs/instagramclone/domain/comment/entity/CommentEntity.java
@@ -42,6 +42,10 @@ public abstract class CommentEntity extends BaseEntity {
         return (long) likes.size();
     }
 
+    public Long getCommentCount() {
+        return (long) comments.size();
+    }
+
     public CommentEntity(String content, UserEntity user) {
         this.content = content;
         this.user = user;

--- a/src/main/java/com/zoooohs/instagramclone/domain/comment/entity/CommentEntity.java
+++ b/src/main/java/com/zoooohs/instagramclone/domain/comment/entity/CommentEntity.java
@@ -32,8 +32,11 @@ public abstract class CommentEntity extends BaseEntity {
     @JoinColumn(name = "user_id", nullable = false)
     private UserEntity user;
 
-    @OneToMany(mappedBy = "comment", fetch = FetchType.LAZY)
+    @OneToMany(mappedBy = "comment", fetch = FetchType.LAZY, cascade = CascadeType.REMOVE)
     private Set<CommentLikeEntity> likes = new HashSet<>();
+
+    @OneToMany(mappedBy = "comment", fetch = FetchType.LAZY, cascade = CascadeType.REMOVE)
+    private Set<CommentCommentEntity> comments = new HashSet<>();
 
     public Long getLikeCount() {
         return (long) likes.size();

--- a/src/main/java/com/zoooohs/instagramclone/domain/comment/entity/PostCommentEntity.java
+++ b/src/main/java/com/zoooohs/instagramclone/domain/comment/entity/PostCommentEntity.java
@@ -1,0 +1,28 @@
+package com.zoooohs.instagramclone.domain.comment.entity;
+
+import com.zoooohs.instagramclone.domain.post.entity.PostEntity;
+import com.zoooohs.instagramclone.domain.user.entity.UserEntity;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import lombok.Setter;
+
+import javax.persistence.*;
+
+
+@Getter
+@Setter
+@NoArgsConstructor
+@Entity(name = "post_comment")
+@DiscriminatorValue("post_comment")
+public class PostCommentEntity extends CommentEntity {
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "post_id", nullable = false)
+    private PostEntity post;
+
+    @Builder
+    public PostCommentEntity(String content, PostEntity post, UserEntity user) {
+        super(content, user);
+        this.post = post;
+    }
+}

--- a/src/main/java/com/zoooohs/instagramclone/domain/comment/repository/CommentCommentRepository.java
+++ b/src/main/java/com/zoooohs/instagramclone/domain/comment/repository/CommentCommentRepository.java
@@ -1,9 +1,9 @@
 package com.zoooohs.instagramclone.domain.comment.repository;
 
-import com.zoooohs.instagramclone.domain.comment.entity.CommentEntity;
+import com.zoooohs.instagramclone.domain.comment.entity.CommentCommentEntity;
 import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.stereotype.Repository;
 
 @Repository
-public interface CommentRepository extends JpaRepository<CommentEntity, Long> {}
+public interface CommentCommentRepository extends JpaRepository<CommentCommentEntity, Long> {}
 

--- a/src/main/java/com/zoooohs/instagramclone/domain/comment/repository/CommentCommentRepository.java
+++ b/src/main/java/com/zoooohs/instagramclone/domain/comment/repository/CommentCommentRepository.java
@@ -1,8 +1,12 @@
 package com.zoooohs.instagramclone.domain.comment.repository;
 
 import com.zoooohs.instagramclone.domain.comment.entity.CommentCommentEntity;
+import org.springframework.data.domain.PageRequest;
 import org.springframework.data.domain.Pageable;
+import org.springframework.data.jpa.repository.EntityGraph;
 import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Query;
+import org.springframework.data.repository.query.Param;
 import org.springframework.stereotype.Repository;
 
 import java.util.List;
@@ -10,5 +14,13 @@ import java.util.List;
 @Repository
 public interface CommentCommentRepository extends JpaRepository<CommentCommentEntity, Long> {
     List<CommentCommentEntity> findByCommentId(Long commentId, Pageable pageable);
+
+    @EntityGraph("comment-user")
+    @Query("SELECT c FROM comment_comment c WHERE c.comment.id = :id ORDER BY c.likes.size DESC")
+    List<CommentCommentEntity> findCommentCommentsOrderByLikesSize(@Param("id") Long id, Pageable pageable);
+
+    @EntityGraph("comment-user")
+    @Query("SELECT c FROM comment_comment c WHERE c.comment.id = :id ORDER BY c.comments.size DESC")
+    List<CommentCommentEntity> findCommentCommentsOrderByCommentsSize(@Param("id") Long id, Pageable pageable);
 }
 

--- a/src/main/java/com/zoooohs/instagramclone/domain/comment/repository/CommentCommentRepository.java
+++ b/src/main/java/com/zoooohs/instagramclone/domain/comment/repository/CommentCommentRepository.java
@@ -1,9 +1,14 @@
 package com.zoooohs.instagramclone.domain.comment.repository;
 
 import com.zoooohs.instagramclone.domain.comment.entity.CommentCommentEntity;
+import org.springframework.data.domain.Pageable;
 import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.stereotype.Repository;
 
+import java.util.List;
+
 @Repository
-public interface CommentCommentRepository extends JpaRepository<CommentCommentEntity, Long> {}
+public interface CommentCommentRepository extends JpaRepository<CommentCommentEntity, Long> {
+    List<CommentCommentEntity> findByCommentId(Long commentId, Pageable pageable);
+}
 

--- a/src/main/java/com/zoooohs/instagramclone/domain/comment/repository/CommentRepository.java
+++ b/src/main/java/com/zoooohs/instagramclone/domain/comment/repository/CommentRepository.java
@@ -5,5 +5,7 @@ import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.stereotype.Repository;
 
 @Repository
-public interface CommentRepository extends JpaRepository<CommentEntity, Long> {}
+public interface CommentRepository extends JpaRepository<CommentEntity, Long> {
+    CommentEntity findByIdAndUserId(Long commentId, Long id);
+}
 

--- a/src/main/java/com/zoooohs/instagramclone/domain/comment/repository/PostCommentRepository.java
+++ b/src/main/java/com/zoooohs/instagramclone/domain/comment/repository/PostCommentRepository.java
@@ -1,0 +1,17 @@
+package com.zoooohs.instagramclone.domain.comment.repository;
+
+import com.zoooohs.instagramclone.domain.comment.entity.PostCommentEntity;
+import org.springframework.data.domain.Pageable;
+import org.springframework.data.jpa.repository.EntityGraph;
+import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.stereotype.Repository;
+
+import java.util.List;
+
+@Repository
+public interface PostCommentRepository extends JpaRepository<PostCommentEntity, Long> {
+    @EntityGraph("comment-user")
+    List<PostCommentEntity> findByPostId(Long postId, Pageable pageable);
+
+    PostCommentEntity findByIdAndUserId(Long commentId, Long userId);
+}

--- a/src/main/java/com/zoooohs/instagramclone/domain/comment/repository/PostCommentRepository.java
+++ b/src/main/java/com/zoooohs/instagramclone/domain/comment/repository/PostCommentRepository.java
@@ -4,6 +4,8 @@ import com.zoooohs.instagramclone.domain.comment.entity.PostCommentEntity;
 import org.springframework.data.domain.Pageable;
 import org.springframework.data.jpa.repository.EntityGraph;
 import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Query;
+import org.springframework.data.repository.query.Param;
 import org.springframework.stereotype.Repository;
 
 import java.util.List;
@@ -14,4 +16,12 @@ public interface PostCommentRepository extends JpaRepository<PostCommentEntity, 
     List<PostCommentEntity> findByPostId(Long postId, Pageable pageable);
 
     PostCommentEntity findByIdAndUserId(Long commentId, Long userId);
+
+    @EntityGraph("comment-user")
+    @Query("SELECT c FROM post_comment c WHERE c.post.id = :id ORDER BY c.likes.size DESC")
+    List<PostCommentEntity> findPostCommentsOrderByLikesSize(@Param("id") Long id, Pageable pageable);
+
+    @EntityGraph("comment-user")
+    @Query("SELECT c FROM post_comment c WHERE c.post.id = :id ORDER BY c.comments.size DESC")
+    List<PostCommentEntity> findPostCommentsOrderByCommentsSize(@Param("id") Long id, Pageable pageable);
 }

--- a/src/main/java/com/zoooohs/instagramclone/domain/comment/service/CommentService.java
+++ b/src/main/java/com/zoooohs/instagramclone/domain/comment/service/CommentService.java
@@ -7,7 +7,9 @@ import com.zoooohs.instagramclone.domain.user.dto.UserDto;
 import java.util.List;
 
 public interface CommentService {
-    CommentDto create(CommentDto commentDto, Long postId, UserDto userDto);
+    CommentDto createPostComment(CommentDto commentDto, Long postId, UserDto userDto);
+
+    CommentDto createCommentComment(CommentDto commentDto, Long commentId, UserDto userDto);
 
     List<CommentDto> getPostCommentList(Long postId, PageModel pageModel, Long userId);
 

--- a/src/main/java/com/zoooohs/instagramclone/domain/comment/service/CommentService.java
+++ b/src/main/java/com/zoooohs/instagramclone/domain/comment/service/CommentService.java
@@ -13,6 +13,8 @@ public interface CommentService {
 
     List<CommentDto> getPostCommentList(Long postId, PageModel pageModel, Long userId);
 
+    List<CommentDto> getCommentCommentList(Long commentId, PageModel pageModel, Long id);
+
     CommentDto updateComment(Long commentId, CommentDto commentDto, UserDto userDto);
 
     Long deleteById(Long commentId, UserDto userDto);

--- a/src/main/java/com/zoooohs/instagramclone/domain/comment/service/CommentServiceImpl.java
+++ b/src/main/java/com/zoooohs/instagramclone/domain/comment/service/CommentServiceImpl.java
@@ -61,11 +61,26 @@ public class CommentServiceImpl implements CommentService {
         PostEntity post = this.postRepository.findById(postId).orElseThrow(() -> new ZooooException(ErrorCode.POST_NOT_FOUND));
         List<PostCommentEntity> comments = this.postCommentRepository.findByPostId(post.getId(), PageRequest.of(pageModel.getIndex(), pageModel.getSize()));
         return comments.stream().map(entity -> {
-            CommentDto dto = this.modelMapper.map(entity, CommentDto.class);
-            boolean isLiked = entity.getLikes().stream().filter(like -> like.getUser().getId().equals(userId)).findFirst().isPresent();
-            dto.isLiked(isLiked);
-            return dto;
+            CommentEntity commentEntity = entity;
+            return makeCommentDto(userId, commentEntity);
         }).collect(Collectors.toList());
+    }
+
+    @Override
+    public List<CommentDto> getCommentCommentList(Long commentId, PageModel pageModel, Long userId) {
+        CommentEntity comment = commentRepository.findById(commentId).orElseThrow(() -> new ZooooException(ErrorCode.COMMENT_NOT_FOUND));
+        List<CommentCommentEntity> comments = commentCommentRepository.findByCommentId(comment.getId(), PageRequest.of(pageModel.getIndex(), pageModel.getSize()));
+        return comments.stream().map(entity -> {
+            CommentEntity commentEntity = entity;
+            return makeCommentDto(userId, commentEntity);
+        }).collect(Collectors.toList());
+    }
+
+    private CommentDto makeCommentDto(Long userId, CommentEntity commentEntity) {
+        CommentDto dto = this.modelMapper.map(commentEntity, CommentDto.class);
+        boolean isLiked = commentEntity.getLikes().stream().filter(like -> like.getUser().getId().equals(userId)).findFirst().isPresent();
+        dto.isLiked(isLiked);
+        return dto;
     }
 
     @Transactional

--- a/src/main/java/com/zoooohs/instagramclone/domain/comment/service/CommentServiceImpl.java
+++ b/src/main/java/com/zoooohs/instagramclone/domain/comment/service/CommentServiceImpl.java
@@ -71,23 +71,23 @@ public class CommentServiceImpl implements CommentService {
     @Transactional
     @Override
     public CommentDto updateComment(Long commentId, CommentDto commentDto, UserDto userDto) {
-        PostCommentEntity comment = this.postCommentRepository.findByIdAndUserId(commentId, userDto.getId());
+        CommentEntity comment = this.commentRepository.findByIdAndUserId(commentId, userDto.getId());
         if (comment == null) {
             throw new ZooooException(ErrorCode.COMMENT_NOT_FOUND);
         }
         comment.setContent(commentDto.getContent());
-        comment = this.postCommentRepository.save(comment);
+        comment = this.commentRepository.save(comment);
         return this.modelMapper.map(comment, CommentDto.class);
     }
 
     @Transactional
     @Override
     public Long deleteById(Long commentId, UserDto userDto) {
-        PostCommentEntity comment = this.postCommentRepository.findByIdAndUserId(commentId, userDto.getId());
+        CommentEntity comment = this.commentRepository.findByIdAndUserId(commentId, userDto.getId());
         if (comment == null) {
             throw new ZooooException(ErrorCode.COMMENT_NOT_FOUND);
         }
-        this.postCommentRepository.delete(comment);
+        this.commentRepository.delete(comment);
         return commentId;
     }
 }

--- a/src/main/java/com/zoooohs/instagramclone/domain/comment/service/CommentServiceImpl.java
+++ b/src/main/java/com/zoooohs/instagramclone/domain/comment/service/CommentServiceImpl.java
@@ -1,22 +1,26 @@
 package com.zoooohs.instagramclone.domain.comment.service;
 
 import com.zoooohs.instagramclone.domain.comment.dto.CommentDto;
+import com.zoooohs.instagramclone.domain.comment.entity.CommentCommentEntity;
 import com.zoooohs.instagramclone.domain.comment.entity.CommentEntity;
+import com.zoooohs.instagramclone.domain.comment.entity.PostCommentEntity;
+import com.zoooohs.instagramclone.domain.comment.repository.CommentCommentRepository;
 import com.zoooohs.instagramclone.domain.comment.repository.CommentRepository;
+import com.zoooohs.instagramclone.domain.comment.repository.PostCommentRepository;
 import com.zoooohs.instagramclone.domain.common.model.PageModel;
-import com.zoooohs.instagramclone.domain.like.repository.CommentLikeRepository;
 import com.zoooohs.instagramclone.domain.post.entity.PostEntity;
 import com.zoooohs.instagramclone.domain.post.repository.PostRepository;
 import com.zoooohs.instagramclone.domain.user.dto.UserDto;
 import com.zoooohs.instagramclone.domain.user.entity.UserEntity;
+import com.zoooohs.instagramclone.domain.user.repository.UserRepository;
 import com.zoooohs.instagramclone.exception.ErrorCode;
 import com.zoooohs.instagramclone.exception.ZooooException;
 import lombok.RequiredArgsConstructor;
 import org.modelmapper.ModelMapper;
 import org.springframework.data.domain.PageRequest;
 import org.springframework.stereotype.Service;
-
 import org.springframework.transaction.annotation.Transactional;
+
 import java.util.List;
 import java.util.stream.Collectors;
 
@@ -26,25 +30,36 @@ public class CommentServiceImpl implements CommentService {
 
     private final ModelMapper modelMapper;
     private final CommentRepository commentRepository;
-    private final CommentLikeRepository commentLikeRepository;
+    private final PostCommentRepository postCommentRepository;
+    private final CommentCommentRepository commentCommentRepository;
     private final PostRepository postRepository;
+    private final UserRepository userRepository;
 
     @Transactional
     @Override
-    public CommentDto create(CommentDto commentDto, Long postId, UserDto userDto) {
-        UserEntity user = UserEntity.builder().id(userDto.getId()).build();
+    public CommentDto createPostComment(CommentDto commentDto, Long postId, UserDto userDto) {
+        UserEntity user = userRepository.getById(userDto.getId());
         PostEntity post = this.postRepository.findById(postId).orElseThrow(() -> new ZooooException(ErrorCode.POST_NOT_FOUND));
-        CommentEntity comment = this.modelMapper.map(commentDto, CommentEntity.class);
+        PostCommentEntity comment = this.modelMapper.map(commentDto, PostCommentEntity.class);
         comment.setPost(post);
         comment.setUser(user);
-        comment = this.commentRepository.save(comment);
+        comment = this.postCommentRepository.save(comment);
         return this.modelMapper.map(comment, CommentDto.class);
+    }
+
+    @Override
+    public CommentDto createCommentComment(CommentDto commentDto, Long commentId, UserDto userDto) {
+        UserEntity user = userRepository.getById(userDto.getId());
+        CommentEntity comment = commentRepository.findById(commentId).orElseThrow(() -> new ZooooException(ErrorCode.COMMENT_NOT_FOUND));
+        CommentCommentEntity commentComment = CommentCommentEntity.builder().user(user).comment(comment).content(commentDto.getContent()).build();
+        commentComment = commentCommentRepository.save(commentComment);
+        return this.modelMapper.map(commentComment, CommentDto.class);
     }
 
     @Override
     public List<CommentDto> getPostCommentList(Long postId, PageModel pageModel, Long userId) {
         PostEntity post = this.postRepository.findById(postId).orElseThrow(() -> new ZooooException(ErrorCode.POST_NOT_FOUND));
-        List<CommentEntity> comments = this.commentRepository.findByPostId(post.getId(), PageRequest.of(pageModel.getIndex(), pageModel.getSize()));
+        List<PostCommentEntity> comments = this.postCommentRepository.findByPostId(post.getId(), PageRequest.of(pageModel.getIndex(), pageModel.getSize()));
         return comments.stream().map(entity -> {
             CommentDto dto = this.modelMapper.map(entity, CommentDto.class);
             boolean isLiked = entity.getLikes().stream().filter(like -> like.getUser().getId().equals(userId)).findFirst().isPresent();
@@ -56,23 +71,23 @@ public class CommentServiceImpl implements CommentService {
     @Transactional
     @Override
     public CommentDto updateComment(Long commentId, CommentDto commentDto, UserDto userDto) {
-        CommentEntity comment = this.commentRepository.findByIdAndUserId(commentId, userDto.getId());
+        PostCommentEntity comment = this.postCommentRepository.findByIdAndUserId(commentId, userDto.getId());
         if (comment == null) {
             throw new ZooooException(ErrorCode.COMMENT_NOT_FOUND);
         }
         comment.setContent(commentDto.getContent());
-        comment = this.commentRepository.save(comment);
+        comment = this.postCommentRepository.save(comment);
         return this.modelMapper.map(comment, CommentDto.class);
     }
 
     @Transactional
     @Override
     public Long deleteById(Long commentId, UserDto userDto) {
-        CommentEntity comment = this.commentRepository.findByIdAndUserId(commentId, userDto.getId());
+        PostCommentEntity comment = this.postCommentRepository.findByIdAndUserId(commentId, userDto.getId());
         if (comment == null) {
             throw new ZooooException(ErrorCode.COMMENT_NOT_FOUND);
         }
-        this.commentRepository.delete(comment);
+        this.postCommentRepository.delete(comment);
         return commentId;
     }
 }

--- a/src/main/java/com/zoooohs/instagramclone/domain/comment/service/CommentServiceImpl.java
+++ b/src/main/java/com/zoooohs/instagramclone/domain/comment/service/CommentServiceImpl.java
@@ -59,7 +59,22 @@ public class CommentServiceImpl implements CommentService {
     @Override
     public List<CommentDto> getPostCommentList(Long postId, PageModel pageModel, Long userId) {
         PostEntity post = this.postRepository.findById(postId).orElseThrow(() -> new ZooooException(ErrorCode.POST_NOT_FOUND));
-        List<PostCommentEntity> comments = this.postCommentRepository.findByPostId(post.getId(), PageRequest.of(pageModel.getIndex(), pageModel.getSize()));
+        List<PostCommentEntity> comments;
+        if (pageModel.getSortKey() == null) {
+            comments = this.postCommentRepository.findByPostId(post.getId(), PageRequest.of(pageModel.getIndex(), pageModel.getSize()));
+        }
+        else {
+            switch (pageModel.getSortKey()) {
+                case LIKE:
+                    comments = postCommentRepository.findPostCommentsOrderByLikesSize(post.getId(), PageRequest.of(pageModel.getIndex(), pageModel.getSize()));
+                    break;
+                case COMMENT:
+                    comments = postCommentRepository.findPostCommentsOrderByCommentsSize(post.getId(), PageRequest.of(pageModel.getIndex(), pageModel.getSize()));
+                    break;
+                default:
+                    comments = this.postCommentRepository.findByPostId(post.getId(), PageRequest.of(pageModel.getIndex(), pageModel.getSize()));
+            }
+        }
         return comments.stream().map(entity -> {
             CommentEntity commentEntity = entity;
             return makeCommentDto(userId, commentEntity);
@@ -69,7 +84,22 @@ public class CommentServiceImpl implements CommentService {
     @Override
     public List<CommentDto> getCommentCommentList(Long commentId, PageModel pageModel, Long userId) {
         CommentEntity comment = commentRepository.findById(commentId).orElseThrow(() -> new ZooooException(ErrorCode.COMMENT_NOT_FOUND));
-        List<CommentCommentEntity> comments = commentCommentRepository.findByCommentId(comment.getId(), PageRequest.of(pageModel.getIndex(), pageModel.getSize()));
+        List<CommentCommentEntity> comments;
+        if (pageModel.getSortKey() == null) {
+            comments = this.commentCommentRepository.findByCommentId(comment.getId(), PageRequest.of(pageModel.getIndex(), pageModel.getSize()));
+        }
+        else {
+            switch (pageModel.getSortKey()) {
+                case LIKE:
+                    comments = commentCommentRepository.findCommentCommentsOrderByLikesSize(comment.getId(), PageRequest.of(pageModel.getIndex(), pageModel.getSize()));
+                    break;
+                case COMMENT:
+                    comments = commentCommentRepository.findCommentCommentsOrderByCommentsSize(comment.getId(), PageRequest.of(pageModel.getIndex(), pageModel.getSize()));
+                    break;
+                default:
+                    comments = this.commentCommentRepository.findByCommentId(comment.getId(), PageRequest.of(pageModel.getIndex(), pageModel.getSize()));
+            }
+        }
         return comments.stream().map(entity -> {
             CommentEntity commentEntity = entity;
             return makeCommentDto(userId, commentEntity);

--- a/src/main/java/com/zoooohs/instagramclone/domain/common/entity/BaseEntity.java
+++ b/src/main/java/com/zoooohs/instagramclone/domain/common/entity/BaseEntity.java
@@ -15,7 +15,7 @@ import java.time.LocalDateTime;
 @NoArgsConstructor
 @MappedSuperclass
 @EntityListeners(AuditingEntityListener.class)
-public class BaseEntity {
+public abstract class BaseEntity {
     @Id
     @GeneratedValue(strategy = GenerationType.IDENTITY)
     protected Long id;

--- a/src/main/java/com/zoooohs/instagramclone/domain/common/model/PageModel.java
+++ b/src/main/java/com/zoooohs/instagramclone/domain/common/model/PageModel.java
@@ -1,5 +1,6 @@
 package com.zoooohs.instagramclone.domain.common.model;
 
+import com.zoooohs.instagramclone.domain.common.type.SortKeyType;
 import io.swagger.v3.oas.annotations.media.Schema;
 import lombok.*;
 
@@ -11,10 +12,13 @@ public class PageModel {
     protected int index;
     @Schema(description = "페이지 당 로우 개수")
     protected int size;
+    @Schema(description = "정렬 키워드")
+    private SortKeyType sortKey;
 
     @Builder
-    public PageModel(int index, int size) {
+    public PageModel(int index, int size, SortKeyType sortKey) {
         this.index = index;
         this.size = size;
+        this.sortKey = sortKey;
     }
 }

--- a/src/main/java/com/zoooohs/instagramclone/domain/common/model/SearchModel.java
+++ b/src/main/java/com/zoooohs/instagramclone/domain/common/model/SearchModel.java
@@ -1,6 +1,7 @@
 package com.zoooohs.instagramclone.domain.common.model;
 
 import com.zoooohs.instagramclone.domain.common.type.SearchKeyType;
+import com.zoooohs.instagramclone.domain.common.type.SortKeyType;
 import io.swagger.v3.oas.annotations.media.Schema;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
@@ -18,8 +19,8 @@ public class SearchModel extends PageModel {
     @Schema(name = "searchKey", description = "검색 종류. (이름, 해쉬 태그, ...)")
     private SearchKeyType searchKey;
 
-    public SearchModel(int index, int size, String keyword, SearchKeyType searchKey) {
-        super(index, size);
+    public SearchModel(int index, int size, SortKeyType sortKey, String keyword, SearchKeyType searchKey) {
+        super(index, size, sortKey);
         this.keyword = keyword;
         this.searchKey = searchKey;
     }

--- a/src/main/java/com/zoooohs/instagramclone/domain/common/type/AccountStatusType.java
+++ b/src/main/java/com/zoooohs/instagramclone/domain/common/type/AccountStatusType.java
@@ -1,0 +1,5 @@
+package com.zoooohs.instagramclone.domain.common.type;
+
+public enum AccountStatusType {
+    WAITING, VERIFIED
+}

--- a/src/main/java/com/zoooohs/instagramclone/domain/common/type/SortKeyType.java
+++ b/src/main/java/com/zoooohs/instagramclone/domain/common/type/SortKeyType.java
@@ -1,0 +1,5 @@
+package com.zoooohs.instagramclone.domain.common.type;
+
+public enum SortKeyType {
+    COMMENT, LIKE;
+}

--- a/src/main/java/com/zoooohs/instagramclone/domain/like/controller/LikeController.java
+++ b/src/main/java/com/zoooohs/instagramclone/domain/like/controller/LikeController.java
@@ -63,7 +63,7 @@ public class LikeController {
         return likeService.likeComment(commentId, userDto);
     }
 
-    @Operation(summary = "게시글 좋아요 취소", description = "특정 게시글 좋아요 취소.")
+    @Operation(summary = "통합 좋아요 취소", description = "댓글, 게시글 좋아요 id로 취소. [주의] 1.0.0 버전의 DELETE /post/{postId}/like, DELETE /comment/{commentId}/like 는 제거 되었습니다. 본 API 로 통합되었습니다.")
     @ApiResponses(value = {
             @ApiResponse(
                     responseCode = "200", description = "좋아요 취소 성공. 좋아요 ID 반환",
@@ -74,24 +74,8 @@ public class LikeController {
                     content = { @Content(mediaType = "application/json", schema = @Schema(implementation = ZooooExceptionResponse.class)) }
             ),
     })
-    @DeleteMapping("/post/{postId}/like")
-    public Long unlike(@PathVariable Long postId, @AuthenticationPrincipal UserDto userDto) {
-        return likeService.unlikePost(postId, userDto);
-    }
-
-    @Operation(summary = "댓글 좋아요 취소", description = "특정 댓글 좋아요 취소.")
-    @ApiResponses(value = {
-            @ApiResponse(
-                    responseCode = "200", description = "좋아요 취소 성공. 좋아요 ID 반환",
-                    content = { @Content(mediaType = "application/json", schema = @Schema(implementation = Long.class)) }
-            ),
-            @ApiResponse(
-                    responseCode = "404", description = "좋아요를 찾을 수 없음",
-                    content = { @Content(mediaType = "application/json", schema = @Schema(implementation = ZooooExceptionResponse.class)) }
-            ),
-    })
-    @DeleteMapping("/comment/{commentId}/like")
-    public Long unlikeComment(@PathVariable Long commentId, @AuthenticationPrincipal UserDto userDto) {
-        return likeService.unlikeComment(commentId, userDto);
+    @DeleteMapping("/like/{likeId}")
+    public Long unlike(@PathVariable Long likeId, @AuthenticationPrincipal UserDto userDto) {
+        return likeService.unlike(likeId, userDto);
     }
 }

--- a/src/main/java/com/zoooohs/instagramclone/domain/like/entity/CommentLikeEntity.java
+++ b/src/main/java/com/zoooohs/instagramclone/domain/like/entity/CommentLikeEntity.java
@@ -1,33 +1,28 @@
 package com.zoooohs.instagramclone.domain.like.entity;
 
 import com.zoooohs.instagramclone.domain.comment.entity.CommentEntity;
-import com.zoooohs.instagramclone.domain.common.entity.BaseEntity;
 import com.zoooohs.instagramclone.domain.user.entity.UserEntity;
 import lombok.Builder;
-import lombok.Data;
+import lombok.Getter;
 import lombok.NoArgsConstructor;
+import lombok.Setter;
 
 import javax.persistence.*;
 
-@Data
+@Getter
+@Setter
 @NoArgsConstructor
 @Entity(name = "comment_like")
-@Table(uniqueConstraints = {
-        @UniqueConstraint(name = "u_comment_user_comment_like", columnNames = {"comment_id", "user_id"}),
-})
-public class CommentLikeEntity extends BaseEntity {
+@DiscriminatorValue("comment_like")
+public class CommentLikeEntity extends LikeEntity {
     @ManyToOne(fetch = FetchType.LAZY)
     @JoinColumn(name = "comment_id", nullable = false)
     private CommentEntity comment;
 
-    @ManyToOne(fetch = FetchType.LAZY)
-    @JoinColumn(name = "user_id", nullable = false)
-    private UserEntity user;
-
     @Builder
     public CommentLikeEntity(CommentEntity comment, UserEntity user) {
+        super(user);
         this.comment = comment;
-        this.user = user;
     }
 }
 

--- a/src/main/java/com/zoooohs/instagramclone/domain/like/entity/LikeEntity.java
+++ b/src/main/java/com/zoooohs/instagramclone/domain/like/entity/LikeEntity.java
@@ -1,0 +1,25 @@
+package com.zoooohs.instagramclone.domain.like.entity;
+
+import com.zoooohs.instagramclone.domain.common.entity.BaseEntity;
+import com.zoooohs.instagramclone.domain.user.entity.UserEntity;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import lombok.Setter;
+
+import javax.persistence.*;
+
+@Getter
+@Setter
+@NoArgsConstructor
+@Entity(name = "likes")
+@Inheritance(strategy = InheritanceType.JOINED)
+@DiscriminatorColumn(name = "LikeType")
+public abstract class LikeEntity extends BaseEntity {
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "user_id", nullable = false)
+    protected UserEntity user;
+
+    public LikeEntity(UserEntity user) {
+        this.user = user;
+    }
+}

--- a/src/main/java/com/zoooohs/instagramclone/domain/like/entity/PostLikeEntity.java
+++ b/src/main/java/com/zoooohs/instagramclone/domain/like/entity/PostLikeEntity.java
@@ -1,32 +1,24 @@
 package com.zoooohs.instagramclone.domain.like.entity;
 
-import com.zoooohs.instagramclone.domain.common.entity.BaseEntity;
 import com.zoooohs.instagramclone.domain.post.entity.PostEntity;
 import com.zoooohs.instagramclone.domain.user.entity.UserEntity;
-import lombok.Builder;
-import lombok.Data;
-import lombok.NoArgsConstructor;
+import lombok.*;
 
 import javax.persistence.*;
 
-@Data
+@Getter
+@Setter
 @NoArgsConstructor
 @Entity(name = "post_like")
-@Table(uniqueConstraints = {
-        @UniqueConstraint(name = "u_post_user_post_like", columnNames = {"post_id", "user_id"}),
-})
-public class PostLikeEntity extends BaseEntity {
+@DiscriminatorValue("post_like")
+public class PostLikeEntity extends LikeEntity {
     @ManyToOne(fetch = FetchType.LAZY)
     @JoinColumn(name = "post_id", nullable = false)
     private PostEntity post;
 
-    @ManyToOne(fetch = FetchType.LAZY)
-    @JoinColumn(name = "user_id", nullable = false)
-    private UserEntity user;
-
     @Builder
     public PostLikeEntity(PostEntity post, UserEntity user) {
+        super(user);
         this.post = post;
-        this.user = user;
     }
 }

--- a/src/main/java/com/zoooohs/instagramclone/domain/like/repository/LikeRepository.java
+++ b/src/main/java/com/zoooohs/instagramclone/domain/like/repository/LikeRepository.java
@@ -1,0 +1,12 @@
+package com.zoooohs.instagramclone.domain.like.repository;
+
+import com.zoooohs.instagramclone.domain.like.entity.LikeEntity;
+import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.stereotype.Repository;
+
+import java.util.Optional;
+
+@Repository
+public interface LikeRepository extends JpaRepository<LikeEntity, Long> {
+    Optional<LikeEntity> findByIdAndUserId(Long likeId, Long userId);
+}

--- a/src/main/java/com/zoooohs/instagramclone/domain/like/service/LikeService.java
+++ b/src/main/java/com/zoooohs/instagramclone/domain/like/service/LikeService.java
@@ -13,4 +13,6 @@ public interface LikeService {
     CommentLikeDto likeComment(Long commentId, UserDto userDto);
 
     Long unlikeComment(Long commentId, UserDto userDto);
+
+    Long unlike(Long likeId, UserDto userDto);
 }

--- a/src/main/java/com/zoooohs/instagramclone/domain/like/service/LikeServiceImpl.java
+++ b/src/main/java/com/zoooohs/instagramclone/domain/like/service/LikeServiceImpl.java
@@ -5,8 +5,10 @@ import com.zoooohs.instagramclone.domain.comment.repository.CommentRepository;
 import com.zoooohs.instagramclone.domain.like.dto.CommentLikeDto;
 import com.zoooohs.instagramclone.domain.like.dto.PostLikeDto;
 import com.zoooohs.instagramclone.domain.like.entity.CommentLikeEntity;
+import com.zoooohs.instagramclone.domain.like.entity.LikeEntity;
 import com.zoooohs.instagramclone.domain.like.entity.PostLikeEntity;
 import com.zoooohs.instagramclone.domain.like.repository.CommentLikeRepository;
+import com.zoooohs.instagramclone.domain.like.repository.LikeRepository;
 import com.zoooohs.instagramclone.domain.like.repository.PostLikeRepository;
 import com.zoooohs.instagramclone.domain.post.entity.PostEntity;
 import com.zoooohs.instagramclone.domain.post.repository.PostRepository;
@@ -17,7 +19,6 @@ import com.zoooohs.instagramclone.exception.ZooooException;
 import lombok.RequiredArgsConstructor;
 import org.modelmapper.ModelMapper;
 import org.springframework.stereotype.Service;
-
 import org.springframework.transaction.annotation.Transactional;
 
 @Service
@@ -29,6 +30,7 @@ public class LikeServiceImpl implements LikeService {
     private final CommentRepository commentRepository;
     private final CommentLikeRepository commentLikeRepository;
     private final ModelMapper modelMapper;
+    private final LikeRepository likeRepository;
 
     @Transactional
     @Override
@@ -77,6 +79,14 @@ public class LikeServiceImpl implements LikeService {
         }
         Long likeId = commentLike.getId();
         commentLikeRepository.delete(commentLike);
+        return likeId;
+    }
+
+    @Transactional
+    @Override
+    public Long unlike(Long likeId, UserDto userDto) {
+        LikeEntity like = likeRepository.findByIdAndUserId(likeId, userDto.getId()).orElseThrow(() -> new ZooooException(ErrorCode.LIKE_NOT_FOUND));
+        likeRepository.delete(like);
         return likeId;
     }
 }

--- a/src/main/java/com/zoooohs/instagramclone/domain/mail/service/MailService.java
+++ b/src/main/java/com/zoooohs/instagramclone/domain/mail/service/MailService.java
@@ -1,4 +1,4 @@
-package com.zoooohs.instagramclone.domain.service;
+package com.zoooohs.instagramclone.domain.mail.service;
 
 public interface MailService {
     void send(String to, String subject, String text);

--- a/src/main/java/com/zoooohs/instagramclone/domain/mail/service/MailServiceImpl.java
+++ b/src/main/java/com/zoooohs/instagramclone/domain/mail/service/MailServiceImpl.java
@@ -1,4 +1,4 @@
-package com.zoooohs.instagramclone.domain.service;
+package com.zoooohs.instagramclone.domain.mail.service;
 
 import com.zoooohs.instagramclone.exception.ErrorCode;
 import com.zoooohs.instagramclone.exception.ZooooException;

--- a/src/main/java/com/zoooohs/instagramclone/domain/post/entity/PostEntity.java
+++ b/src/main/java/com/zoooohs/instagramclone/domain/post/entity/PostEntity.java
@@ -1,5 +1,6 @@
 package com.zoooohs.instagramclone.domain.post.entity;
 
+import com.zoooohs.instagramclone.domain.comment.entity.PostCommentEntity;
 import com.zoooohs.instagramclone.domain.common.entity.BaseEntity;
 import com.zoooohs.instagramclone.domain.hashtag.entity.HashTagEntity;
 import com.zoooohs.instagramclone.domain.like.entity.PostLikeEntity;
@@ -42,11 +43,14 @@ public class PostEntity extends BaseEntity {
     @OneToMany(mappedBy = "post", cascade = CascadeType.ALL, fetch = FetchType.LAZY)
     private Set<PhotoEntity> photos = new HashSet<>();
 
-    @OneToMany(mappedBy = "post", fetch = FetchType.LAZY)
+    @OneToMany(mappedBy = "post", fetch = FetchType.LAZY, cascade = CascadeType.REMOVE)
     private Set<PostLikeEntity> likes = new HashSet<>();
 
     @OneToMany(mappedBy = "post", fetch = FetchType.LAZY, cascade = {CascadeType.MERGE, CascadeType.PERSIST}, orphanRemoval = true)
     private Set<HashTagEntity> hashTags = new HashSet<>();
+
+    @OneToMany(mappedBy = "post", fetch = FetchType.LAZY, cascade = CascadeType.REMOVE)
+    private Set<PostCommentEntity> comments = new HashSet<>();
 
     public Long getLikeCount() {
         return (long) likes.size();

--- a/src/main/java/com/zoooohs/instagramclone/domain/service/MailService.java
+++ b/src/main/java/com/zoooohs/instagramclone/domain/service/MailService.java
@@ -1,0 +1,5 @@
+package com.zoooohs.instagramclone.domain.service;
+
+public interface MailService {
+    void send(String to, String subject, String text);
+}

--- a/src/main/java/com/zoooohs/instagramclone/domain/service/MailServiceImpl.java
+++ b/src/main/java/com/zoooohs/instagramclone/domain/service/MailServiceImpl.java
@@ -1,0 +1,33 @@
+package com.zoooohs.instagramclone.domain.service;
+
+import com.zoooohs.instagramclone.exception.ErrorCode;
+import com.zoooohs.instagramclone.exception.ZooooException;
+import lombok.RequiredArgsConstructor;
+import org.springframework.mail.javamail.JavaMailSender;
+import org.springframework.stereotype.Service;
+
+import javax.mail.Message;
+import javax.mail.internet.InternetAddress;
+import javax.mail.internet.MimeMessage;
+
+@Service
+@RequiredArgsConstructor
+public class MailServiceImpl implements MailService {
+    private final JavaMailSender mailSender;
+
+    @Override
+    public void send(String to, String subject, String text) {
+        try {
+            MimeMessage message = mailSender.createMimeMessage();
+            message.addRecipient(Message.RecipientType.TO, new InternetAddress(to, to, "UTF-8"));
+            message.setSubject(subject);
+            message.setText(text, "UTF-8", "html");
+
+            mailSender.send(message);
+
+        } catch (Exception e) {
+            e.printStackTrace();
+            throw new ZooooException(ErrorCode.INTERNAL_ERROR);
+        }
+    }
+}

--- a/src/main/java/com/zoooohs/instagramclone/domain/user/controller/UserController.java
+++ b/src/main/java/com/zoooohs/instagramclone/domain/user/controller/UserController.java
@@ -62,4 +62,24 @@ public class UserController {
     public UserDto.Info updateBio(@RequestBody UserDto.Info userDto, @AuthenticationPrincipal UserDto authUserDto) {
         return this.userService.updateBio(userDto.getBio(), authUserDto);
     }
+
+    @Operation(summary = "비밀번호 변경", description = "기존 비밀번호 새로운 비밀번호를 입력받아, 새로운 비밀번호로 변경한다.")
+    @ApiResponses(value = {
+            @ApiResponse(
+                    responseCode = "200", description = "변경 성공. 유저 정보 반환",
+                    content = { @Content(mediaType = "application/json", schema = @Schema(implementation = UserDto.Info.class)) }
+            ),
+            @ApiResponse(
+                    responseCode = "404", description = "유저 정보가 일치하지 않음",
+                    content = { @Content(mediaType = "application/json", schema = @Schema(implementation = ZooooExceptionResponse.class)) }
+            ),
+            @ApiResponse(
+                    responseCode = "409", description = "동일한 비밀번호로 변경 시도",
+                    content = { @Content(mediaType = "application/json", schema = @Schema(implementation = ZooooExceptionResponse.class)) }
+            ),
+    })
+    @PatchMapping("/user/{userId}/password")
+    public UserDto.Info updatePassword(@PathVariable("userId") Long userId, @RequestBody UserDto.UpdatePassword passwordDto, @AuthenticationPrincipal UserDto authUserDto) {
+        return userService.updatePassword(userId, passwordDto, authUserDto);
+    }
 }

--- a/src/main/java/com/zoooohs/instagramclone/domain/user/controller/UserController.java
+++ b/src/main/java/com/zoooohs/instagramclone/domain/user/controller/UserController.java
@@ -58,9 +58,10 @@ public class UserController {
                     content = { @Content(mediaType = "application/json", schema = @Schema(implementation = UserDto.Info.class)) }
             ),
     })
-    @PatchMapping("/user/bio")
-    public UserDto.Info updateBio(@RequestBody UserDto.Info userDto, @AuthenticationPrincipal UserDto authUserDto) {
-        return this.userService.updateBio(userDto.getBio(), authUserDto);
+    @PatchMapping("/user/{userId}/bio")
+    public UserDto.Info updateBio(@PathVariable("userId") Long userId, @RequestBody UserDto.Info userDto, @AuthenticationPrincipal UserDto authUserDto) {
+        userDto.setId(userId);
+        return this.userService.updateBio(userDto, authUserDto);
     }
 
     @Operation(summary = "비밀번호 변경", description = "기존 비밀번호 새로운 비밀번호를 입력받아, 새로운 비밀번호로 변경한다.")

--- a/src/main/java/com/zoooohs/instagramclone/domain/user/dto/UserDto.java
+++ b/src/main/java/com/zoooohs/instagramclone/domain/user/dto/UserDto.java
@@ -56,6 +56,28 @@ public class UserDto {
         }
     }
 
+    @Schema(name = "UserDto.UpdatePassword", description = "비밀 번호 변경을 위한 DTO")
+    @Getter
+    @Setter
+    @EqualsAndHashCode
+    @NoArgsConstructor
+    public static class UpdatePassword {
+        @Schema(description = "기존 비밀번호")
+        private String oldPassword;
+        @Schema(description = "새로운 비밀번호")
+        private String newPassword;
+
+        public boolean isSamePassword() {
+            return oldPassword.equals(newPassword);
+        }
+
+        @Builder
+        public UpdatePassword(String oldPassword, String newPassword) {
+            this.oldPassword = oldPassword;
+            this.newPassword = newPassword;
+        }
+    }
+
     public String getUsername() {
         return email;
     }

--- a/src/main/java/com/zoooohs/instagramclone/domain/user/dto/UserDto.java
+++ b/src/main/java/com/zoooohs/instagramclone/domain/user/dto/UserDto.java
@@ -2,12 +2,11 @@ package com.zoooohs.instagramclone.domain.user.dto;
 
 import com.zoooohs.instagramclone.domain.photo.dto.PhotoDto;
 import io.swagger.v3.oas.annotations.media.Schema;
-import lombok.Builder;
-import lombok.Data;
-import lombok.NoArgsConstructor;
-import lombok.Setter;
+import lombok.*;
 
-@Data
+@Getter
+@Setter
+@EqualsAndHashCode
 @NoArgsConstructor
 public class UserDto {
     private Long id;

--- a/src/main/java/com/zoooohs/instagramclone/domain/user/entity/UserEntity.java
+++ b/src/main/java/com/zoooohs/instagramclone/domain/user/entity/UserEntity.java
@@ -3,10 +3,7 @@ package com.zoooohs.instagramclone.domain.user.entity;
 import com.zoooohs.instagramclone.domain.common.entity.BaseEntity;
 import com.zoooohs.instagramclone.domain.common.type.AccountStatusType;
 import com.zoooohs.instagramclone.domain.photo.entity.PhotoEntity;
-import lombok.Builder;
-import lombok.Getter;
-import lombok.NoArgsConstructor;
-import lombok.Setter;
+import lombok.*;
 import org.springframework.security.core.GrantedAuthority;
 import org.springframework.security.core.userdetails.UserDetails;
 
@@ -24,6 +21,7 @@ import java.util.Collection;
                 @NamedAttributeNode("photo")
         })
 })
+@EqualsAndHashCode(of = {"name", "email", "id"})
 public class UserEntity extends BaseEntity implements UserDetails {
 
     @Email
@@ -50,11 +48,14 @@ public class UserEntity extends BaseEntity implements UserDetails {
     private AccountStatusType status = AccountStatusType.WAITING;
 
     @Builder
-    public UserEntity(Long id, String email, String password, String name) {
+    public UserEntity(Long id, String email, String password, String name, String bio, PhotoEntity photo, AccountStatusType status) {
         this.id = id;
         this.email = email;
         this.password = password;
         this.name = name;
+        this.bio = bio;
+        this.photo = photo;
+        this.status = status;
     }
 
     @Override

--- a/src/main/java/com/zoooohs/instagramclone/domain/user/entity/UserEntity.java
+++ b/src/main/java/com/zoooohs/instagramclone/domain/user/entity/UserEntity.java
@@ -1,6 +1,7 @@
 package com.zoooohs.instagramclone.domain.user.entity;
 
 import com.zoooohs.instagramclone.domain.common.entity.BaseEntity;
+import com.zoooohs.instagramclone.domain.common.type.AccountStatusType;
 import com.zoooohs.instagramclone.domain.photo.entity.PhotoEntity;
 import lombok.Builder;
 import lombok.Getter;
@@ -43,6 +44,10 @@ public class UserEntity extends BaseEntity implements UserDetails {
     @OneToOne(fetch = FetchType.LAZY, orphanRemoval = true)
     @JoinColumn(name = "photo_id")
     private PhotoEntity photo;
+
+    @Enumerated(EnumType.STRING)
+    @Column(name = "status")
+    private AccountStatusType status = AccountStatusType.WAITING;
 
     @Builder
     public UserEntity(Long id, String email, String password, String name) {

--- a/src/main/java/com/zoooohs/instagramclone/domain/user/service/UserService.java
+++ b/src/main/java/com/zoooohs/instagramclone/domain/user/service/UserService.java
@@ -6,9 +6,9 @@ import com.zoooohs.instagramclone.domain.user.dto.UserDto;
 import java.util.List;
 
 public interface UserService {
-    public UserDto.Info getInfo(Long userId);
+    UserDto.Info getInfo(Long userId);
 
-    public UserDto.Info updateBio(String bio, UserDto authUserDto);
+    UserDto.Info updateBio(UserDto.Info userDto, UserDto authUserDto);
 
     List<UserDto.Info> getUsers(SearchModel searchModel);
 

--- a/src/main/java/com/zoooohs/instagramclone/domain/user/service/UserService.java
+++ b/src/main/java/com/zoooohs/instagramclone/domain/user/service/UserService.java
@@ -11,4 +11,6 @@ public interface UserService {
     public UserDto.Info updateBio(String bio, UserDto authUserDto);
 
     List<UserDto.Info> getUsers(SearchModel searchModel);
+
+    UserDto.Info updatePassword(Long userId, UserDto.UpdatePassword passwordDto, UserDto authUserDto);
 }

--- a/src/main/java/com/zoooohs/instagramclone/domain/user/service/UserServiceImpl.java
+++ b/src/main/java/com/zoooohs/instagramclone/domain/user/service/UserServiceImpl.java
@@ -37,11 +37,17 @@ public class UserServiceImpl implements UserService {
 
     @Transactional
     @Override
-    public UserDto.Info updateBio(String bio, UserDto authUserDto) {
-        UserEntity user = this.userRepository.findById(authUserDto.getId()).orElseThrow(() -> new ZooooException(ErrorCode.USER_NOT_FOUND));
-        user.setBio(bio);
-        user = this.userRepository.save(user);
-        return this.modelMapper.map(user, UserDto.Info.class);
+    public UserDto.Info updateBio(UserDto.Info userDto, UserDto authUserDto) {
+        if (!userDto.getId().equals(authUserDto.getId())) {
+            throw new ZooooException(ErrorCode.USER_NOT_FOUND);
+        }
+        return userRepository.findById(authUserDto.getId())
+                .map(entity -> {
+                    entity.setBio(userDto.getBio());
+                    return userRepository.save(entity);
+                })
+                .map(entity -> modelMapper.map(entity,UserDto.Info.class))
+                .orElseThrow(() -> new ZooooException(ErrorCode.USER_NOT_FOUND));
     }
 
     @Override

--- a/src/main/java/com/zoooohs/instagramclone/exception/ErrorCode.java
+++ b/src/main/java/com/zoooohs/instagramclone/exception/ErrorCode.java
@@ -10,6 +10,7 @@ public enum ErrorCode {
 
     // 401 UNAUTHORIZED
     TOKEN_EXPIRED(HttpStatus.UNAUTHORIZED, "만료된 토큰 입니다."),
+    USER_NOT_VERIFIED(HttpStatus.UNAUTHORIZED, "Email 인증이 완료되지 않은 계정입니다."),
 
     // 404 NOT FOUND
     LOGIN_WRONG_INFO(HttpStatus.NOT_FOUND, "사용자 정보를 찾을 수 없습니다."),

--- a/src/main/java/com/zoooohs/instagramclone/exception/ErrorCode.java
+++ b/src/main/java/com/zoooohs/instagramclone/exception/ErrorCode.java
@@ -27,6 +27,7 @@ public enum ErrorCode {
     ALREADY_FOLLOWED_USER(HttpStatus.CONFLICT, "이미 팔로우 한 사용자 입니다."),
     FOLLOWING_SELF(HttpStatus.CONFLICT, "자기 자신은 영원한 친구 입니다."),
     SAME_PASSWORD(HttpStatus.CONFLICT, "동일한 비밀번호 입니다."),
+    ALREADY_VERIFIED(HttpStatus.CONFLICT, "이미 검증 되었습니다."),
 
     // 500 INTERNAL
     INTERNAL_ERROR(HttpStatus.INTERNAL_SERVER_ERROR, "서버 내부 오류"),

--- a/src/main/java/com/zoooohs/instagramclone/exception/ErrorCode.java
+++ b/src/main/java/com/zoooohs/instagramclone/exception/ErrorCode.java
@@ -26,6 +26,7 @@ public enum ErrorCode {
     ALREADY_LIKED_COMMENT(HttpStatus.CONFLICT, "이미 좋아요 한 댓글 입니다."),
     ALREADY_FOLLOWED_USER(HttpStatus.CONFLICT, "이미 팔로우 한 사용자 입니다."),
     FOLLOWING_SELF(HttpStatus.CONFLICT, "자기 자신은 영원한 친구 입니다."),
+    SAME_PASSWORD(HttpStatus.CONFLICT, "동일한 비밀번호 입니다."),
 
     // 500 INTERNAL
     INTERNAL_ERROR(HttpStatus.INTERNAL_SERVER_ERROR, "서버 내부 오류"),

--- a/src/main/resources/application.yaml
+++ b/src/main/resources/application.yaml
@@ -30,6 +30,9 @@ logging:
 
 instagram-clone:
   version: 1.0.0
+  mail:
+    username: ${MAIL_USERNAME}
+    password: ${MAIL_PASSWORD}
   storage:
     filesystem: ${STORAGE_FS}
   jwt:

--- a/src/main/resources/application.yaml
+++ b/src/main/resources/application.yaml
@@ -29,7 +29,7 @@ logging:
           hibernate: info
 
 instagram-clone:
-  version: 1.0.0
+  version: 1.0.1
   mail:
     username: ${MAIL_USERNAME}
     password: ${MAIL_PASSWORD}

--- a/src/test/java/com/zoooohs/instagramclone/configure/WithAuthUser.java
+++ b/src/test/java/com/zoooohs/instagramclone/configure/WithAuthUser.java
@@ -10,4 +10,5 @@ import java.lang.annotation.RetentionPolicy;
 public @interface WithAuthUser {
     long id();
     String email();
+    String name();
 }

--- a/src/test/java/com/zoooohs/instagramclone/configure/WithAuthUserSecurityContextFactory.java
+++ b/src/test/java/com/zoooohs/instagramclone/configure/WithAuthUserSecurityContextFactory.java
@@ -11,9 +11,10 @@ public class WithAuthUserSecurityContextFactory implements WithSecurityContextFa
     @Override
     public SecurityContext createSecurityContext(WithAuthUser annotation) {
         String email = annotation.email();
+        String name = annotation.name();
         Long id = annotation.id();
 
-        UserDto userDto = UserDto.builder().id(id).email(email).build();
+        UserDto userDto = UserDto.builder().id(id).email(email).name(name).build();
         UsernamePasswordAuthenticationToken token =
                 new UsernamePasswordAuthenticationToken(userDto, "passwd");
         SecurityContext context = SecurityContextHolder.getContext();

--- a/src/test/java/com/zoooohs/instagramclone/domain/auth/controller/AuthControllerTest.java
+++ b/src/test/java/com/zoooohs/instagramclone/domain/auth/controller/AuthControllerTest.java
@@ -5,7 +5,12 @@ import com.fasterxml.jackson.databind.PropertyNamingStrategies;
 import com.zoooohs.instagramclone.configuration.JwtTokenProvider;
 import com.zoooohs.instagramclone.domain.auth.dto.AuthDto;
 import com.zoooohs.instagramclone.domain.auth.service.AuthService;
+import com.zoooohs.instagramclone.domain.service.MailService;
+import com.zoooohs.instagramclone.exception.ErrorCode;
+import com.zoooohs.instagramclone.exception.ZooooException;
+import org.hamcrest.Matchers;
 import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
 import org.mockito.Spy;
@@ -16,15 +21,21 @@ import org.springframework.boot.test.autoconfigure.web.servlet.WebMvcTest;
 import org.springframework.boot.test.mock.mockito.MockBean;
 import org.springframework.http.MediaType;
 import org.springframework.security.authentication.AuthenticationManager;
+import org.springframework.security.crypto.factory.PasswordEncoderFactories;
+import org.springframework.security.crypto.password.PasswordEncoder;
 import org.springframework.test.web.servlet.MockMvc;
 import org.springframework.test.web.servlet.request.MockMvcRequestBuilders;
 import org.springframework.test.web.servlet.result.MockMvcResultMatchers;
 
+import java.net.URLEncoder;
+import java.nio.charset.StandardCharsets;
+import java.util.Base64;
 import java.util.Date;
 
-import static org.mockito.ArgumentMatchers.any;
-import static org.mockito.ArgumentMatchers.anyString;
+import static org.mockito.ArgumentMatchers.*;
 import static org.mockito.BDDMockito.given;
+import static org.mockito.Mockito.times;
+import static org.mockito.Mockito.verify;
 
 @WebMvcTest(controllers = AuthController.class)
 @ExtendWith(MockitoExtension.class)
@@ -43,9 +54,15 @@ public class AuthControllerTest {
     @MockBean
     AuthService authService;
 
+    @MockBean
+    MailService mailService;
+
+    PasswordEncoder passwordEncoder;
+
     @BeforeEach
     public void setUp() {
         objectMapper = new ObjectMapper();
+        passwordEncoder = PasswordEncoderFactories.createDelegatingPasswordEncoder();
     }
 
     @Test
@@ -61,12 +78,15 @@ public class AuthControllerTest {
         signUpDto.setPassword(password);
         signUpDto.setName(name);
 
-        given(authService.signUp(any(AuthDto.SignUp.class))).willReturn(getToken());
+        given(authService.signUp(any(AuthDto.SignUp.class))).willReturn(Base64.getEncoder().encode((signUpDto.getEmail()+signUpDto.getName()).getBytes()).toString());
 
         mockMvc.perform(MockMvcRequestBuilders.post(url)
-                .contentType(MediaType.APPLICATION_JSON)
-                .content(objectMapper.writeValueAsBytes(signUpDto)))
-                .andExpect(MockMvcResultMatchers.status().isOk());
+                        .header("origin", "localhost:8080")
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content(objectMapper.writeValueAsBytes(signUpDto)))
+                .andExpect(MockMvcResultMatchers.status().isOk())
+                .andExpect(MockMvcResultMatchers.jsonPath("$", Matchers.is("OK")));
+        verify(mailService, times(1)).send(anyString(), anyString(), anyString());
     }
 
     @Test
@@ -76,16 +96,21 @@ public class AuthControllerTest {
         Date now = new Date();
         String email = "sign-up-test-id"+now.getTime()+"@email.com";
         String password = "passwd";
-        AuthDto.SignIn signIn = new AuthDto.SignIn();
-        signIn.setEmail(email);
-        signIn.setPassword(password);
+        AuthDto.SignIn signIn = AuthDto.SignIn.builder().email(email).password(password).build();
+        AuthDto.SignIn signIn401 = AuthDto.SignIn.builder().email("1"+email).password(password).build();
 
-        given(authService.signIn(any(AuthDto.SignIn.class))).willReturn(getToken());
+        given(authService.signIn(eq(signIn))).willReturn(getToken());
+        given(authService.signIn(eq(signIn401))).willThrow(new ZooooException(ErrorCode.USER_NOT_VERIFIED));
 
         mockMvc.perform(MockMvcRequestBuilders.post(url)
-                .contentType(MediaType.APPLICATION_JSON)
-                .content(objectMapper.writeValueAsBytes(signIn)))
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content(objectMapper.writeValueAsBytes(signIn)))
                 .andExpect(MockMvcResultMatchers.status().isOk());
+
+        mockMvc.perform(MockMvcRequestBuilders.post(url)
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content(objectMapper.writeValueAsBytes(signIn401)))
+                .andExpect(MockMvcResultMatchers.status().isUnauthorized());
     }
 
     @Test
@@ -127,5 +152,26 @@ public class AuthControllerTest {
 
     private AuthDto.Token getToken() {
         return AuthDto.Token.builder().accessToken("a.b.c").refreshToken("a.b.c").build();
+    }
+
+    @DisplayName("GET /auth/verification?email=&token= 토큰 맞으면 true, 아니면 404")
+    @Test
+    public void verificationTest() throws Exception {
+        String url = "/auth/verification";
+
+        given(authService.verification(eq("test@test.com"), anyString())).willReturn(true);
+        given(authService.verification(eq("test@test1.com"), anyString())).willThrow(new ZooooException(ErrorCode.USER_NOT_FOUND));
+
+        mockMvc.perform(MockMvcRequestBuilders.get(url)
+                        .queryParam("email", "test@test.com")
+                        .queryParam("token", passwordEncoder.encode("test@test.com"+"test"))
+                )
+                .andExpect(MockMvcResultMatchers.status().isOk());
+
+        mockMvc.perform(MockMvcRequestBuilders.get(url)
+                        .queryParam("email", "test@test1.com")
+                        .queryParam("token", passwordEncoder.encode("test@test.com"+"test"))
+                )
+                .andExpect(MockMvcResultMatchers.status().isNotFound());
     }
 }

--- a/src/test/java/com/zoooohs/instagramclone/domain/auth/controller/AuthControllerTest.java
+++ b/src/test/java/com/zoooohs/instagramclone/domain/auth/controller/AuthControllerTest.java
@@ -5,7 +5,7 @@ import com.fasterxml.jackson.databind.PropertyNamingStrategies;
 import com.zoooohs.instagramclone.configuration.JwtTokenProvider;
 import com.zoooohs.instagramclone.domain.auth.dto.AuthDto;
 import com.zoooohs.instagramclone.domain.auth.service.AuthService;
-import com.zoooohs.instagramclone.domain.service.MailService;
+import com.zoooohs.instagramclone.domain.mail.service.MailService;
 import com.zoooohs.instagramclone.exception.ErrorCode;
 import com.zoooohs.instagramclone.exception.ZooooException;
 import org.hamcrest.Matchers;

--- a/src/test/java/com/zoooohs/instagramclone/domain/auth/service/AuthServiceTest.java
+++ b/src/test/java/com/zoooohs/instagramclone/domain/auth/service/AuthServiceTest.java
@@ -4,11 +4,13 @@ import com.zoooohs.instagramclone.configuration.JwtTokenProvider;
 import com.zoooohs.instagramclone.domain.auth.dto.AuthDto;
 import com.zoooohs.instagramclone.domain.auth.entity.RefreshTokenEntity;
 import com.zoooohs.instagramclone.domain.auth.repository.RefreshTokenRepository;
+import com.zoooohs.instagramclone.domain.common.type.AccountStatusType;
 import com.zoooohs.instagramclone.domain.user.entity.UserEntity;
 import com.zoooohs.instagramclone.domain.user.repository.UserRepository;
 import com.zoooohs.instagramclone.exception.ErrorCode;
 import com.zoooohs.instagramclone.exception.ZooooException;
 import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
 import org.mockito.Mock;
@@ -27,7 +29,7 @@ import static org.junit.jupiter.api.Assertions.*;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.ArgumentMatchers.eq;
 import static org.mockito.BDDMockito.given;
-import static org.mockito.Mockito.mockStatic;
+import static org.mockito.Mockito.*;
 
 @ExtendWith(MockitoExtension.class)
 public class AuthServiceTest {
@@ -86,10 +88,9 @@ public class AuthServiceTest {
         given(this.userRepository.findByEmailAndName(eq(email), eq(name))).willReturn(Optional.ofNullable(null));
         given(this.userRepository.save(any(UserEntity.class))).willReturn(user);
 
-        AuthDto.Token actual = this.authService.signUp(signUpDto);
+        String actual = this.authService.signUp(signUpDto);
 
-        assertEquals(email, this.jwtTokenProvider.getAccessTokenUserId(actual.getAccessToken()));
-        assertEquals(email, this.jwtTokenProvider.getRefreshTokenUserId(actual.getRefreshToken()));
+        assertTrue(passwordEncoder.matches(user.getEmail()+user.getName(), actual));
     }
 
     @Test
@@ -112,6 +113,7 @@ public class AuthServiceTest {
     public void singInTest() {
         AuthDto.SignIn signInDto = AuthDto.SignIn.builder().email(testUser.getEmail()).password(testUserPasswdDecode).build();
 
+        testUser.setStatus(AccountStatusType.VERIFIED);
         given(this.userRepository.findByEmail(eq(testUser.getEmail()))).willReturn(Optional.of(testUser));
 
         AuthDto.Token actual = this.authService.signIn(signInDto);
@@ -119,14 +121,33 @@ public class AuthServiceTest {
         assertEquals(testUser.getEmail(), jwtTokenProvider.getAccessTokenUserId(actual.getAccessToken()));
     }
 
+    @DisplayName("인증 받지 않은 계정 DTO -> USER_NOT_VERIFIED throw")
     @Test
-    public void singInFailureTest() {
+    public void singInFailure401Test() {
+        AuthDto.SignIn signInDto = AuthDto.SignIn.builder().email(testUser.getEmail()).password("passwd").build();
+
+        testUser.setStatus(AccountStatusType.WAITING);
+        given(this.userRepository.findByEmail(eq(testUser.getEmail()))).willReturn(Optional.of(testUser));
+
+        try {
+            authService.signIn(signInDto);
+            fail();
+        } catch (ZooooException e) {
+            assertEquals(ErrorCode.USER_NOT_VERIFIED, e.getErrorCode());
+        } catch (Exception e) {
+            fail();
+        }
+    }
+
+    @DisplayName("올바르지 못한 계정 정보 로그인 -> LOGIN_WRONG_INFO throw")
+    @Test
+    public void singInFailure404Test() {
         AuthDto.SignIn signInDto = AuthDto.SignIn.builder().email(testUser.getEmail()).password("wrong-passwd").build();
 
         given(this.userRepository.findByEmail(eq(testUser.getEmail()))).willReturn(Optional.of(testUser));
 
         try {
-            this.authService.signIn(signInDto);
+            authService.signIn(signInDto);
             fail();
         } catch (ZooooException e) {
             assertEquals(ErrorCode.LOGIN_WRONG_INFO, e.getErrorCode());
@@ -209,4 +230,29 @@ public class AuthServiceTest {
         assertTrue(duplicatedActual);
         assertFalse(notDuplicatedActual);
     }
+
+    @DisplayName("email, token 받아서 유효한 토큰이면 true 아니면 404 throw")
+    @Test
+    public void verificationTest() {
+        String email = "test@test.com";
+        String token = passwordEncoder.encode(email+"test");
+
+        given(userRepository.findByEmail(eq(email))).willReturn(Optional.of(UserEntity.builder().email(email).name("test").build()));
+
+        boolean actual = authService.verification(email, token);
+
+        assertTrue(actual);
+        verify(userRepository, times(1)).save(any(UserEntity.class));
+
+        try {
+            email = "1"+email;
+            authService.verification(email, token);
+            fail();
+        } catch (ZooooException e) {
+            assertEquals(ErrorCode.USER_NOT_FOUND, e.getErrorCode());
+        } catch (Exception e) {
+            fail();
+        }
+    }
+
 }

--- a/src/test/java/com/zoooohs/instagramclone/domain/comment/controller/CommentControllerTest.java
+++ b/src/test/java/com/zoooohs/instagramclone/domain/comment/controller/CommentControllerTest.java
@@ -6,6 +6,7 @@ import com.zoooohs.instagramclone.configure.WithAuthUser;
 import com.zoooohs.instagramclone.domain.comment.dto.CommentDto;
 import com.zoooohs.instagramclone.domain.comment.service.CommentService;
 import com.zoooohs.instagramclone.domain.common.model.PageModel;
+import com.zoooohs.instagramclone.domain.common.model.SearchModel;
 import com.zoooohs.instagramclone.domain.user.dto.UserDto;
 import com.zoooohs.instagramclone.exception.ErrorCode;
 import com.zoooohs.instagramclone.exception.ZooooException;
@@ -98,10 +99,8 @@ public class CommentControllerTest {
             commentDtos.add(commentDto);
         }
 
-        PageModel pageModel = PageModel.builder().index(0).size(20).build();
-
-        given(this.commentService.getPostCommentList(eq(postId), any(PageModel.class), eq(1L))).willReturn(commentDtos);
-        given(this.commentService.getPostCommentList(eq(2L), any(PageModel.class), eq(1L))).willThrow(new ZooooException(ErrorCode.POST_NOT_FOUND));
+        given(this.commentService.getPostCommentList(eq(postId), any(SearchModel.class), eq(1L))).willReturn(commentDtos);
+        given(this.commentService.getPostCommentList(eq(2L), any(SearchModel.class), eq(1L))).willThrow(new ZooooException(ErrorCode.POST_NOT_FOUND));
 
         mockMvc.perform(get(url)
                         .param("index", "0")

--- a/src/test/java/com/zoooohs/instagramclone/domain/comment/controller/CommentControllerTest.java
+++ b/src/test/java/com/zoooohs/instagramclone/domain/comment/controller/CommentControllerTest.java
@@ -62,7 +62,7 @@ public class CommentControllerTest {
 
     @DisplayName("POST /post/{postId}/comment body, jwt 입력 받아, comment json return")
     @Test
-    @WithAuthUser(email = "user1@test.test", id = 1L)
+    @WithAuthUser(email = "user1@test.test", id = 1L, name = "test")
     public void createPostCommentTest() throws Exception {
         Long postId = 1L;
         String content = "comment content";
@@ -82,7 +82,7 @@ public class CommentControllerTest {
 
     @DisplayName("GET /post/{postId}/comment 입력, comment 리스트 반환, 없는 postid의 경우 404")
     @Test
-    @WithAuthUser(email = "user1@test.test", id = 1L)
+    @WithAuthUser(email = "user1@test.test", id = 1L, name = "test")
     public void getPostCommentListTest() throws Exception {
         Long postId = 1L;
         String url = String.format("/post/%d/comment", postId);
@@ -119,7 +119,7 @@ public class CommentControllerTest {
 
     @DisplayName("GET /comment/{commentId}/comment 입력, comment 리스트 반환, 없는 commentId의 경우 404")
     @Test
-    @WithAuthUser(email = "user1@test.test", id = 1L)
+    @WithAuthUser(email = "user1@test.test", id = 1L, name = "test")
     public void getCommentCommentListTest() throws Exception {
         Long commentId = 1L;
         String url = String.format("/comment/%d/comment", commentId);
@@ -156,7 +156,7 @@ public class CommentControllerTest {
 
     @DisplayName("PATCH /comment/{commentId}, body, jwt 입력 받아 comment json 반환. 없는 comment의 경우 404 return")
     @Test
-    @WithAuthUser(email = "user1@test.test", id = 1L)
+    @WithAuthUser(email = "user1@test.test", id = 1L, name = "test")
     public void updateCommentTest() throws Exception {
         String url = String.format("/comment/%d", 1L);
         String url404 = String.format("/comment/%d", 2L);
@@ -179,7 +179,7 @@ public class CommentControllerTest {
 
     @DisplayName("DELETE /comment/{commentId}, jwt 입력 받아, 댓글 삭제후 댓글 id 담긴 json 반환. 없는 댓글의 경우 404 반환")
     @Test
-    @WithAuthUser(email = "user1@test.test", id = 1L)
+    @WithAuthUser(email = "user1@test.test", id = 1L, name = "test")
     public void deleteByIdTest() throws Exception {
         String url = String.format("/comment/%d", 1L);
         String url404 = String.format("/comment/%d", 2L);
@@ -197,7 +197,7 @@ public class CommentControllerTest {
 
     @DisplayName("POST /comment/{commentId}/comment body, jwt 입력 받아, comment json return. 없는 commentId의 경우 404 반환")
     @Test
-    @WithAuthUser(email = "user1@test.test", id = 1L)
+    @WithAuthUser(email = "user1@test.test", id = 1L, name = "test")
     public void createCommentCommentTest() throws Exception {
         Long commentId = 1L;
         String content = "comment content";

--- a/src/test/java/com/zoooohs/instagramclone/domain/comment/repository/CommentCommentRepositoryTest.java
+++ b/src/test/java/com/zoooohs/instagramclone/domain/comment/repository/CommentCommentRepositoryTest.java
@@ -1,7 +1,6 @@
 package com.zoooohs.instagramclone.domain.comment.repository;
 
 import com.zoooohs.instagramclone.domain.comment.entity.CommentCommentEntity;
-import com.zoooohs.instagramclone.domain.comment.entity.CommentEntity;
 import com.zoooohs.instagramclone.domain.comment.entity.PostCommentEntity;
 import com.zoooohs.instagramclone.domain.post.entity.PostEntity;
 import com.zoooohs.instagramclone.domain.post.repository.PostRepository;
@@ -17,7 +16,6 @@ import org.springframework.data.jpa.repository.config.EnableJpaAuditing;
 import org.springframework.security.crypto.factory.PasswordEncoderFactories;
 import org.springframework.security.crypto.password.PasswordEncoder;
 
-import javax.persistence.EntityManager;
 import java.util.Date;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
@@ -26,7 +24,7 @@ import static org.junit.jupiter.api.Assertions.assertNotNull;
 @EnableJpaAuditing
 @DataJpaTest
 @AutoConfigureTestDatabase(replace = AutoConfigureTestDatabase.Replace.NONE)
-public class CommentRepositoryTest {
+public class CommentCommentRepositoryTest {
 
     @Autowired
     PostCommentRepository postCommentRepository;
@@ -39,12 +37,6 @@ public class CommentRepositoryTest {
 
     @Autowired
     CommentCommentRepository commentCommentRepository;
-
-    @Autowired
-    CommentRepository commentRepository;
-
-    @Autowired
-    EntityManager entityManager;
 
     private PasswordEncoder passwordEncoder;
     private PostEntity post;
@@ -73,26 +65,18 @@ public class CommentRepositoryTest {
         postCommentRepository.save(comment);
     }
 
-    @DisplayName("id로 comment 찾기 테스트")
+    @DisplayName("comment save 테스트")
     @Test
-    public void findByIdTest() {
+    public void saveTest() {
         CommentCommentEntity commentCommentEntity = CommentCommentEntity.builder()
                 .content("new Content")
                 .comment(comment)
                 .user(user)
                 .build();
 
+        CommentCommentEntity actual = commentCommentRepository.save(commentCommentEntity);
 
-        commentCommentRepository.save(commentCommentEntity);
-        Long commentId = commentCommentEntity.getId();
-
-        entityManager.flush();
-        entityManager.clear();
-
-
-        CommentEntity actual = commentRepository.findById(commentId).orElse(null);
-
-        assertNotNull(actual);
+        assertNotNull(actual.getId());
         assertEquals(commentCommentEntity.getContent(), actual.getContent());
     }
 }

--- a/src/test/java/com/zoooohs/instagramclone/domain/comment/repository/CommentCommentRepositoryTest.java
+++ b/src/test/java/com/zoooohs/instagramclone/domain/comment/repository/CommentCommentRepositoryTest.java
@@ -12,11 +12,14 @@ import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.autoconfigure.jdbc.AutoConfigureTestDatabase;
 import org.springframework.boot.test.autoconfigure.orm.jpa.DataJpaTest;
+import org.springframework.data.domain.PageRequest;
 import org.springframework.data.jpa.repository.config.EnableJpaAuditing;
 import org.springframework.security.crypto.factory.PasswordEncoderFactories;
 import org.springframework.security.crypto.password.PasswordEncoder;
 
+import java.util.ArrayList;
 import java.util.Date;
+import java.util.List;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertNotNull;
@@ -78,5 +81,28 @@ public class CommentCommentRepositoryTest {
 
         assertNotNull(actual.getId());
         assertEquals(commentCommentEntity.getContent(), actual.getContent());
+    }
+
+    @DisplayName("commentId 받아와 대댓글 리스트 반환하는 Repository 테스트")
+    @Test
+    public void findByCommentIdTest() {
+        List<CommentCommentEntity> commentCommentEntities = new ArrayList<>();
+        for (int i = 0; i < 20; i++) {
+            CommentCommentEntity commentComment = CommentCommentEntity.builder()
+                    .content("new Content")
+                    .comment(comment)
+                    .user(user)
+                    .build();
+
+            commentCommentEntities.add(commentComment);
+        }
+        commentCommentRepository.saveAll(commentCommentEntities);
+
+        List<CommentCommentEntity> actual = commentCommentRepository.findByCommentId(comment.getId(), PageRequest.of(0, 10));
+
+        assertEquals(10, actual.size());
+        for (int i = 0; i < 10; i++) {
+            assertEquals(comment.getId(), actual.get(i).getComment().getId());
+        }
     }
 }

--- a/src/test/java/com/zoooohs/instagramclone/domain/comment/repository/CommentRepositoryTest.java
+++ b/src/test/java/com/zoooohs/instagramclone/domain/comment/repository/CommentRepositoryTest.java
@@ -20,8 +20,7 @@ import org.springframework.security.crypto.password.PasswordEncoder;
 import javax.persistence.EntityManager;
 import java.util.Date;
 
-import static org.junit.jupiter.api.Assertions.assertEquals;
-import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.*;
 
 @EnableJpaAuditing
 @DataJpaTest
@@ -94,5 +93,60 @@ public class CommentRepositoryTest {
 
         assertNotNull(actual);
         assertEquals(commentCommentEntity.getContent(), actual.getContent());
+    }
+
+    @DisplayName("commentRepository.findByIdAndUserId commentId, userId 받아와서 해당 유저의 댓글 가져오는 기능 테스트")
+    @Test
+    public void findByIdAndUserIdTest() {
+        PostCommentEntity comment = new PostCommentEntity();
+        comment.setContent("content22");
+        comment.setUser(user);
+        comment.setPost(post);
+        comment = this.postCommentRepository.save(comment);
+
+        CommentEntity actual = this.commentRepository.findByIdAndUserId(comment.getId(), user.getId());
+        CommentEntity actualNull = this.commentRepository.findByIdAndUserId(comment.getId(), user.getId()+3L);
+
+        assertNotNull(comment);
+        assertEquals(comment.getId(), actual.getId());
+        assertEquals(comment.getContent(), actual.getContent());
+        assertNull(actualNull);
+    }
+
+    @DisplayName("comment Repository delete(commentEntity)로 댓글 삭제 테스트")
+    @Test
+    public void deleteTest() {
+        PostCommentEntity comment = new PostCommentEntity();
+        comment.setContent("content22");
+        comment.setUser(user);
+        comment.setPost(post);
+        comment = this.postCommentRepository.save(comment);
+
+        Long commentId = comment.getId();
+
+        this.commentRepository.delete(comment);
+
+        assertThrows(Exception.class, () -> commentRepository.findById(commentId).orElseThrow(() -> new Exception()));
+    }
+
+    @DisplayName("대댓글의 원글 삭제시, 대댓글도 같이 삭제")
+    @Test
+    public void deleteCascadeTest() {
+        PostCommentEntity comment = new PostCommentEntity();
+        comment.setContent("content22");
+        comment.setUser(user);
+        comment.setPost(post);
+        comment = this.postCommentRepository.save(comment);
+
+        CommentCommentEntity commentComment = CommentCommentEntity.builder()
+                .comment(comment)
+                .user(user)
+                .content("asdf")
+                .build();
+
+
+        this.commentRepository.delete(comment);
+
+        assertTrue(true);
     }
 }

--- a/src/test/java/com/zoooohs/instagramclone/domain/comment/repository/PostCommentRepositoryTest.java
+++ b/src/test/java/com/zoooohs/instagramclone/domain/comment/repository/PostCommentRepositoryTest.java
@@ -1,0 +1,174 @@
+package com.zoooohs.instagramclone.domain.comment.repository;
+
+import com.zoooohs.instagramclone.domain.comment.entity.PostCommentEntity;
+import com.zoooohs.instagramclone.domain.like.entity.CommentLikeEntity;
+import com.zoooohs.instagramclone.domain.like.repository.CommentLikeRepository;
+import com.zoooohs.instagramclone.domain.post.entity.PostEntity;
+import com.zoooohs.instagramclone.domain.post.repository.PostRepository;
+import com.zoooohs.instagramclone.domain.user.entity.UserEntity;
+import com.zoooohs.instagramclone.domain.user.repository.UserRepository;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.autoconfigure.jdbc.AutoConfigureTestDatabase;
+import org.springframework.boot.test.autoconfigure.orm.jpa.DataJpaTest;
+import org.springframework.data.domain.PageRequest;
+import org.springframework.data.domain.Pageable;
+import org.springframework.data.jpa.repository.config.EnableJpaAuditing;
+import org.springframework.security.crypto.factory.PasswordEncoderFactories;
+import org.springframework.security.crypto.password.PasswordEncoder;
+
+import javax.persistence.EntityManager;
+import java.util.ArrayList;
+import java.util.Date;
+import java.util.List;
+
+import static org.junit.jupiter.api.Assertions.*;
+
+@EnableJpaAuditing
+@DataJpaTest
+@AutoConfigureTestDatabase(replace = AutoConfigureTestDatabase.Replace.NONE)
+public class PostCommentRepositoryTest {
+
+    @Autowired
+    PostCommentRepository postCommentRepository;
+
+    @Autowired
+    UserRepository userRepository;
+
+    @Autowired
+    PostRepository postRepository;
+
+    @Autowired
+    CommentLikeRepository commentLikeRepository;
+
+    @Autowired
+    EntityManager entityManager;
+
+    private PasswordEncoder passwordEncoder;
+    private PostEntity post;
+    private UserEntity user;
+
+
+    @BeforeEach
+    public void setUp() {
+        passwordEncoder = PasswordEncoderFactories.createDelegatingPasswordEncoder();
+        Date now = new Date();
+        String testEmail = "tt-sign-up-test-id"+now.getTime()+"@email.com";
+        String testPassword = "passwd";
+        String testName = "sign-up-test-name"+now.getTime();
+        user = new UserEntity();
+        user.setEmail(testEmail);
+        user.setPassword(passwordEncoder.encode(testPassword));
+        user.setName(testName);
+        user = this.userRepository.save(user);
+        post = PostEntity.builder().description("post1").user(user).build();
+        post = this.postRepository.save(post);
+    }
+
+    @DisplayName("comment save 테스트")
+    @Test
+    public void saveTest() {
+        PostCommentEntity comment = new PostCommentEntity();
+        comment.setContent("content");
+        comment.setUser(user);
+        comment.setPost(post);
+
+        PostCommentEntity actual = this.postCommentRepository.save(comment);
+
+        assertEquals(comment.getContent(), actual.getContent());
+        assertTrue(actual.getId() != null);
+    }
+
+    @DisplayName("comment repository findByPostId, postId로 comment list 받아오기 테스트")
+    @Test
+    public void findByPostIdTest() {
+        List<PostCommentEntity> testList = new ArrayList<>();
+        for (int i = 0; i < 30; i++) {
+            PostCommentEntity comment = new PostCommentEntity();
+            comment.setContent("content");
+            comment.setUser(user);
+            comment.setPost(post);
+            testList.add(comment);
+        }
+        this.postCommentRepository.saveAll(testList);
+
+        int pageSize = 20;
+        Pageable pageable = PageRequest.of(0, pageSize);
+
+        List<PostCommentEntity> actual = this.postCommentRepository.findByPostId(post.getId(), pageable);
+
+        assertNotEquals(null, actual);
+        assertEquals(pageSize, actual.size());
+    }
+
+    @DisplayName("findByPostId comment entity list SELECT 할때 likes같이 반환")
+    @Test
+    public void findByPostIdWithLikesTest() {
+        List<PostCommentEntity> testList = new ArrayList<>();
+        for (int i = 0; i < 20; i++) {
+            PostCommentEntity comment = new PostCommentEntity();
+            comment.setContent("content");
+            comment.setUser(user);
+            comment.setPost(post);
+            testList.add(comment);
+        }
+
+        this.postCommentRepository.saveAll(testList);
+
+        CommentLikeEntity commentLike = new CommentLikeEntity();
+        commentLike.setComment(testList.get(0));
+        commentLike.setUser(user);
+
+        commentLikeRepository.save(commentLike);
+
+        entityManager.flush();
+        entityManager.clear();
+
+
+        int pageSize = 20;
+        Pageable pageable = PageRequest.of(0, pageSize);
+
+        List<PostCommentEntity> actual = this.postCommentRepository.findByPostId(post.getId(), pageable);
+
+        assertNotEquals(null, actual);
+        assertEquals(pageSize, actual.size());
+        assertEquals(1, actual.get(0).getLikeCount());
+        assertTrue(actual.get(0).getLikes().stream().filter(l -> l.getUser().getId().equals(user.getId())).findFirst().isPresent());
+    }
+
+    @DisplayName("commentRepository.findByIdAndUserId commentId, userId 받아와서 해당 유저의 댓글 가져오는 기능 테스트")
+    @Test
+    public void findByIdAndUserIdTest() {
+        PostCommentEntity comment = new PostCommentEntity();
+        comment.setContent("content22");
+        comment.setUser(user);
+        comment.setPost(post);
+        comment = this.postCommentRepository.save(comment);
+
+        PostCommentEntity actual = this.postCommentRepository.findByIdAndUserId(comment.getId(), user.getId());
+        PostCommentEntity actualNull = this.postCommentRepository.findByIdAndUserId(comment.getId(), user.getId()+3L);
+
+        assertNotNull(comment);
+        assertEquals(comment.getId(), actual.getId());
+        assertEquals(comment.getContent(), actual.getContent());
+        assertNull(actualNull);
+    }
+
+    @DisplayName("comment Repository delete(commentEntity)로 댓글 삭제 테스트")
+    @Test
+    public void deleteTest() {
+        PostCommentEntity comment = new PostCommentEntity();
+        comment.setContent("content22");
+        comment.setUser(user);
+        comment.setPost(post);
+        comment = this.postCommentRepository.save(comment);
+
+        Long commentId = comment.getId();
+
+        this.postCommentRepository.delete(comment);
+
+        assertThrows(Exception.class, () -> postCommentRepository.findById(commentId).orElseThrow(() -> new Exception()));
+    }
+}

--- a/src/test/java/com/zoooohs/instagramclone/domain/comment/service/CommentServiceTest.java
+++ b/src/test/java/com/zoooohs/instagramclone/domain/comment/service/CommentServiceTest.java
@@ -65,7 +65,7 @@ public class CommentServiceTest {
         commentDto = CommentDto.builder().content("content").build();
         post = PostEntity.builder().id(postId).build();
 
-        pageModel = PageModel.builder().index(0).size(20).build();
+        pageModel = new PageModel(0, 20, null);
 
         postCommentEntity = new PostCommentEntity();
         postCommentEntity.setId(1L);

--- a/src/test/java/com/zoooohs/instagramclone/domain/comment/service/CommentServiceTest.java
+++ b/src/test/java/com/zoooohs/instagramclone/domain/comment/service/CommentServiceTest.java
@@ -158,6 +158,41 @@ public class CommentServiceTest {
         assertTrue(actual.get(0).isLiked());
     }
 
+    @DisplayName("commentId 입력 받아 comment comment list 반환하는 service 테스트")
+    @Test
+    public void getCommentCommentListTest() {
+        Long commentId = 1L;
+
+        CommentEntity comment = PostCommentEntity.builder()
+                .build();
+        comment.setId(commentId);
+
+        ArrayList<CommentCommentEntity> commentEntities = new ArrayList<>();
+        for (int i = 0; i < 20; i++) {
+            CommentCommentEntity commentEntity = CommentCommentEntity.builder()
+                    .content("content " + i)
+                    .user(UserEntity.builder().name("user"+1).id((long) i).build())
+                    .build();
+            CommentLikeEntity commentLike = new CommentLikeEntity();
+            commentLike.setComment(commentEntity);
+            commentLike.setUser(UserEntity.builder().id(userDto.getId()).build());
+            commentEntities.add(commentEntity);
+            Set<CommentLikeEntity>  likes = new HashSet<>();
+            likes.add(commentLike);
+            commentEntity.setLikes(likes);
+        }
+
+        given(this.commentRepository.findById(commentId)).willReturn(Optional.ofNullable(comment));
+        given(commentCommentRepository.findByCommentId(eq(commentId), any(Pageable.class))).willReturn(commentEntities);
+
+        List<CommentDto> actual = this.commentService.getCommentCommentList(commentId, pageModel, userDto.getId());
+
+        assertNotEquals(null, actual);
+        assertTrue(actual.size() <= pageModel.getSize());
+        assertNotNull(actual.get(0).getLikeCount());
+        assertTrue(actual.get(0).isLiked());
+    }
+
     @DisplayName("없는 postId의 경우 POST_NOT_FOUND Exception throw 하는 service테스트")
     @Test
     public void getPostCommentList404FailureTest() {

--- a/src/test/java/com/zoooohs/instagramclone/domain/comment/service/CommentServiceTest.java
+++ b/src/test/java/com/zoooohs/instagramclone/domain/comment/service/CommentServiceTest.java
@@ -183,8 +183,8 @@ public class CommentServiceTest {
         PostCommentEntity newComment = new PostCommentEntity();
         newComment.setId(postCommentEntity.getId());
         newComment.setContent(newContent);
-        given(postCommentRepository.findByIdAndUserId(eq(postCommentEntity.getId()), eq(userDto.getId()))).willReturn(postCommentEntity);
-        given(postCommentRepository.save(any(PostCommentEntity.class))).willReturn(newComment);
+        given(commentRepository.findByIdAndUserId(eq(postCommentEntity.getId()), eq(userDto.getId()))).willReturn(postCommentEntity);
+        given(commentRepository.save(any(PostCommentEntity.class))).willReturn(newComment);
 
         CommentDto actual = commentService.updateComment(postCommentEntity.getId(), commentDto, userDto);
 
@@ -192,10 +192,27 @@ public class CommentServiceTest {
         assertEquals(postCommentEntity.getId(), actual.getId());
     }
 
+    @DisplayName("CommentCommentEntity 수정하여 CommentDto 반환")
+    @Test
+    public void updateCommentCommentTest() {
+        String newContent = "aaa";
+        commentDto.setContent(newContent);
+        CommentCommentEntity newComment = new CommentCommentEntity();
+        newComment.setId(1L);
+        newComment.setContent(newContent);
+
+        given(commentRepository.findByIdAndUserId(eq(postCommentEntity.getId()), eq(userDto.getId()))).willReturn(postCommentEntity);
+        given(commentRepository.save(any(CommentEntity.class))).willReturn(newComment);
+
+        CommentDto actual = commentService.updateComment(postCommentEntity.getId(), commentDto, userDto);
+
+        assertEquals(newContent, actual.getContent());
+    }
+
     @DisplayName("comment service  updateComment(postId, commentDto, userDto) 받아서 db에 comment 없으면 COMMENT_NOT_FOUND 반환 하도록 테스트")
     @Test
     public void updateCommentFailure404Test() {
-        given(postCommentRepository.findByIdAndUserId(eq(postCommentEntity.getId()), eq(userDto.getId()))).willReturn(null);
+        given(commentRepository.findByIdAndUserId(eq(postCommentEntity.getId()), eq(userDto.getId()))).willReturn(null);
         try {
             commentService.updateComment(postCommentEntity.getId(), commentDto, userDto);
             fail();
@@ -210,7 +227,7 @@ public class CommentServiceTest {
     @Test
     public void deleteByIdTest() {
         Long commentId = 1L;
-        given(postCommentRepository.findByIdAndUserId(eq(1L), eq(userDto.getId()))).willReturn(postCommentEntity);
+        given(commentRepository.findByIdAndUserId(eq(1L), eq(userDto.getId()))).willReturn(postCommentEntity);
         Long actual = commentService.deleteById(commentId, userDto);
 
         assertEquals(commentId, actual);
@@ -220,7 +237,7 @@ public class CommentServiceTest {
     @Test
     public void deleteByIdFailure404Test() {
         Long commentId = 1L;
-        given(postCommentRepository.findByIdAndUserId(eq(1L), eq(userDto.getId()))).willReturn(null);
+        given(commentRepository.findByIdAndUserId(eq(1L), eq(userDto.getId()))).willReturn(null);
         try {
             commentService.deleteById(commentId, userDto);
             fail();

--- a/src/test/java/com/zoooohs/instagramclone/domain/follow/controller/FollowControllerTest.java
+++ b/src/test/java/com/zoooohs/instagramclone/domain/follow/controller/FollowControllerTest.java
@@ -63,7 +63,7 @@ public class FollowControllerTest {
 
     @DisplayName("POST /user/{userId}/follow, jwt를 입력받아 follow json 반환, userId 없으면 404, 이미 follow 한 user면 409 반환")
     @Test
-    @WithAuthUser(email = "user1@test.test", id = 1L)
+    @WithAuthUser(email = "user1@test.test", id = 1L, name = "test")
     public void followTest() throws Exception {
         String url409 = String.format("/user/%d/follow", followUserId);
 
@@ -94,7 +94,7 @@ public class FollowControllerTest {
 
     @DisplayName("DELETE /user/{followUserId}/follow, jwt 입력 id 반환. follow가 없을 경우 404, 자기 자신을 언팔로우 할 경우 409")
     @Test
-    @WithAuthUser(email = "user1@test.test", id = 1L)
+    @WithAuthUser(email = "user1@test.test", id = 1L, name = "test")
     public void unfollowTest() throws Exception {
 
         given(followService.unfollow(eq(followUserId), eq(1L))).willReturn(1L);

--- a/src/test/java/com/zoooohs/instagramclone/domain/like/controller/LikeControllerTest.java
+++ b/src/test/java/com/zoooohs/instagramclone/domain/like/controller/LikeControllerTest.java
@@ -60,7 +60,7 @@ public class LikeControllerTest {
 
     @DisplayName("POST /post/{postId}/like 입력받아 Like Json 반환, ost /post/{postId}/like 입력 받아 없는 postId 의 경우 404 반환")
     @Test
-    @WithAuthUser(email = "user1@test.test", id = 1L)
+    @WithAuthUser(email = "user1@test.test", id = 1L, name = "test")
     public void likePostTest() throws Exception {
         String url = String.format("/post/%d/like", 1L);
         String url404 = String.format("/post/%d/like", 2L);
@@ -83,7 +83,7 @@ public class LikeControllerTest {
 
     @DisplayName("POST /comment/{commentId}/like, jwt 입력 받아, like json 반환")
     @Test
-    @WithAuthUser(email = "user1@test.test", id = 1L)
+    @WithAuthUser(email = "user1@test.test", id = 1L, name = "test")
     public void likeCommentTest() throws Exception {
         String url = String.format("/comment/%d/like", 1L);
         String url404 = String.format("/comment/%d/like", 2L);
@@ -106,7 +106,7 @@ public class LikeControllerTest {
 
     @DisplayName("DELETE /like/{likeId} 입력 받아  id 담긴 json 반환")
     @Test
-    @WithAuthUser(email = "user1@test.test", id = 1L)
+    @WithAuthUser(email = "user1@test.test", id = 1L, name = "test")
     public void unlikeTest() throws Exception {
         String url = String.format("/like/%d", 1L);
         String url404 = String.format("/like/%d", 2L);

--- a/src/test/java/com/zoooohs/instagramclone/domain/like/controller/LikeControllerTest.java
+++ b/src/test/java/com/zoooohs/instagramclone/domain/like/controller/LikeControllerTest.java
@@ -81,24 +81,6 @@ public class LikeControllerTest {
                 .andExpect(status().isNotFound());
     }
 
-    @DisplayName("DELETE /post/{postId}/like 입력 받아  id 담긴 json 반환")
-    @Test
-    @WithAuthUser(email = "user1@test.test", id = 1L)
-    public void unlikePostTest() throws Exception {
-        String url = String.format("/post/%d/like", 1L);
-        String url404 = String.format("/post/%d/like", 2L);
-
-        given(likeService.unlikePost(eq(1L), any(UserDto.class))).willReturn(1L);
-        given(likeService.unlikePost(eq(2L), any(UserDto.class))).willThrow(new ZooooException(ErrorCode.LIKE_NOT_FOUND));
-
-        mockMvc.perform(delete(url))
-                .andExpect(status().isOk())
-                .andExpect(MockMvcResultMatchers.content().string("1"));
-
-        mockMvc.perform(delete(url404))
-                .andExpect(status().isNotFound());
-    }
-
     @DisplayName("POST /comment/{commentId}/like, jwt 입력 받아, like json 반환")
     @Test
     @WithAuthUser(email = "user1@test.test", id = 1L)
@@ -122,15 +104,15 @@ public class LikeControllerTest {
                 .andExpect(status().isNotFound());
     }
 
-    @DisplayName("DELETE /comment/{commentId}/like, jwt 입력 받아 like id  반환, comment 혹은 like가 없는 경우 404")
+    @DisplayName("DELETE /like/{likeId} 입력 받아  id 담긴 json 반환")
     @Test
     @WithAuthUser(email = "user1@test.test", id = 1L)
-    public void unlikeCommentTest() throws Exception {
-        String url = String.format("/comment/%d/like", 1L);
-        String url404 = String.format("/comment/%d/like", 2L);
+    public void unlikeTest() throws Exception {
+        String url = String.format("/like/%d", 1L);
+        String url404 = String.format("/like/%d", 2L);
 
-        given(likeService.unlikeComment(eq(1L), any(UserDto.class))).willReturn(1L);
-        given(likeService.unlikeComment(eq(2L), any(UserDto.class))).willThrow(new ZooooException(ErrorCode.LIKE_NOT_FOUND));
+        given(likeService.unlike(eq(1L), any(UserDto.class))).willReturn(1L);
+        given(likeService.unlike(eq(2L), any(UserDto.class))).willThrow(new ZooooException(ErrorCode.LIKE_NOT_FOUND));
 
         mockMvc.perform(delete(url))
                 .andExpect(status().isOk())
@@ -139,5 +121,4 @@ public class LikeControllerTest {
         mockMvc.perform(delete(url404))
                 .andExpect(status().isNotFound());
     }
-
 }

--- a/src/test/java/com/zoooohs/instagramclone/domain/like/repository/CommentLikeRepositoryTest.java
+++ b/src/test/java/com/zoooohs/instagramclone/domain/like/repository/CommentLikeRepositoryTest.java
@@ -1,7 +1,7 @@
 package com.zoooohs.instagramclone.domain.like.repository;
 
-import com.zoooohs.instagramclone.domain.comment.entity.CommentEntity;
-import com.zoooohs.instagramclone.domain.comment.repository.CommentRepository;
+import com.zoooohs.instagramclone.domain.comment.entity.PostCommentEntity;
+import com.zoooohs.instagramclone.domain.comment.repository.PostCommentRepository;
 import com.zoooohs.instagramclone.domain.like.entity.CommentLikeEntity;
 import com.zoooohs.instagramclone.domain.post.entity.PostEntity;
 import com.zoooohs.instagramclone.domain.post.repository.PostRepository;
@@ -38,12 +38,12 @@ public class CommentLikeRepositoryTest {
     PostRepository postRepository;
 
     @Autowired
-    CommentRepository commentRepository;
+    PostCommentRepository postCommentRepository;
 
     private PasswordEncoder passwordEncoder;
     private PostEntity post;
     private UserEntity user;
-    private CommentEntity comment;
+    private PostCommentEntity comment;
 
     @BeforeEach
     public void setUp() {
@@ -60,8 +60,8 @@ public class CommentLikeRepositoryTest {
         post = PostEntity.builder().description("post1").user(user).build();
         post = this.postRepository.save(post);
 
-        comment = CommentEntity.builder().post(post).user(user).content("some content").build();
-        comment = commentRepository.save(comment);
+        comment = PostCommentEntity.builder().post(post).user(user).content("some content").build();
+        comment = postCommentRepository.save(comment);
     }
 
     @DisplayName("like entity save test")

--- a/src/test/java/com/zoooohs/instagramclone/domain/like/repository/LikeRepositoryTest.java
+++ b/src/test/java/com/zoooohs/instagramclone/domain/like/repository/LikeRepositoryTest.java
@@ -3,6 +3,7 @@ package com.zoooohs.instagramclone.domain.like.repository;
 import com.zoooohs.instagramclone.domain.comment.entity.CommentEntity;
 import com.zoooohs.instagramclone.domain.comment.repository.CommentRepository;
 import com.zoooohs.instagramclone.domain.like.entity.CommentLikeEntity;
+import com.zoooohs.instagramclone.domain.like.entity.LikeEntity;
 import com.zoooohs.instagramclone.domain.post.entity.PostEntity;
 import com.zoooohs.instagramclone.domain.post.repository.PostRepository;
 import com.zoooohs.instagramclone.domain.user.entity.UserEntity;
@@ -13,23 +14,27 @@ import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.autoconfigure.jdbc.AutoConfigureTestDatabase;
 import org.springframework.boot.test.autoconfigure.orm.jpa.DataJpaTest;
-import org.springframework.dao.DataIntegrityViolationException;
 import org.springframework.data.jpa.repository.config.EnableJpaAuditing;
 import org.springframework.security.crypto.factory.PasswordEncoderFactories;
 import org.springframework.security.crypto.password.PasswordEncoder;
 
+import javax.persistence.EntityManager;
 import java.util.Date;
+import java.util.List;
+import java.util.Optional;
 
 import static org.junit.jupiter.api.Assertions.*;
-import static org.junit.jupiter.api.Assertions.fail;
 
 @EnableJpaAuditing
 @DataJpaTest
 @AutoConfigureTestDatabase(replace = AutoConfigureTestDatabase.Replace.NONE)
-public class CommentLikeRepositoryTest {
+public class LikeRepositoryTest {
 
     @Autowired
-    CommentLikeRepository likeRepository;
+    LikeRepository likeRepository;
+
+    @Autowired
+    CommentLikeRepository commentLikeRepository;
 
     @Autowired
     UserRepository userRepository;
@@ -39,6 +44,9 @@ public class CommentLikeRepositoryTest {
 
     @Autowired
     CommentRepository commentRepository;
+
+    @Autowired
+    EntityManager entityManager;
 
     private PasswordEncoder passwordEncoder;
     private PostEntity post;
@@ -64,7 +72,7 @@ public class CommentLikeRepositoryTest {
         comment = commentRepository.save(comment);
     }
 
-    @DisplayName("like entity save test")
+    @DisplayName("LikeEntity 저장 후 CommentLikeEntity로 Casting")
     @Test
     public void saveTest() {
         CommentLikeEntity like = CommentLikeEntity.builder().user(user).comment(comment).build();
@@ -74,31 +82,48 @@ public class CommentLikeRepositoryTest {
         assertEquals(like.getComment().getId(), actual.getComment().getId());
     }
 
-    // Entity 상속 Join Patter 쓰면서 어떻게 확인해야 할지 찾아야 함
-    @DisplayName("commentId, userid 쌍이 같은 commentLike row가 insert되어선 안된다")
-    public void commentAndUserUniqueTest() {
+    @DisplayName("LikeEntity 저장 후 LikeRepository에서 id로 읽어와도 CommentEntity로 Casting")
+    @Test
+    public void findTest() {
         CommentLikeEntity like = CommentLikeEntity.builder().user(user).comment(comment).build();
         likeRepository.save(like);
-        CommentLikeEntity like2 = CommentLikeEntity.builder().user(user).comment(comment).build();
 
-        try {
-            likeRepository.save(like2);
-            fail();
-        } catch (DataIntegrityViolationException e) {
-            assertTrue(true);
-        } catch (Exception e) {
-            fail();
-        }
+        Long likeId = like.getId();
+
+        entityManager.clear();
+
+        Optional<LikeEntity> maybeCommentLike = likeRepository.findById(likeId);
+
+        CommentLikeEntity actual = maybeCommentLike.filter(likeEntity -> likeEntity instanceof CommentLikeEntity).map(CommentLikeEntity.class::cast).orElse(null);
+
+        assertNotNull(actual);
+        assertTrue(actual.getId() != null);
+        assertEquals(like.getComment().getId(), actual.getComment().getId());
     }
 
-    @DisplayName("commentId, userId 입력 받아 commnet like entity 찾기")
+    @DisplayName("LikeEntity를 삭제하면 CommentLike도 같이 삭제된다")
     @Test
-    public void findByCommentIdAndUserIdTest() {
+    public void deleteLikeEntityTest() {
         CommentLikeEntity like = CommentLikeEntity.builder().user(user).comment(comment).build();
-        like = likeRepository.save(like);
+        likeRepository.save(like);
 
-        CommentLikeEntity actual = likeRepository.findByCommentIdAndUserId(comment.getId(), user.getId());
+        likeRepository.deleteById(like.getId());
 
-        assertEquals(like.getId(), actual.getId());
+
+        List<CommentLikeEntity> actual = commentLikeRepository.findAll();
+
+        assertEquals(0, actual.size());
+    }
+
+    @DisplayName("없는 ID 삭제는 안된다.")
+    @Test
+    public void deleteNullTest() {
+        try {
+            likeRepository.deleteById(3L);
+            fail();
+        } catch (Exception e) {
+            e.printStackTrace();
+            assertTrue(true);
+        }
     }
 }

--- a/src/test/java/com/zoooohs/instagramclone/domain/like/repository/LikeRepositoryTest.java
+++ b/src/test/java/com/zoooohs/instagramclone/domain/like/repository/LikeRepositoryTest.java
@@ -1,7 +1,7 @@
 package com.zoooohs.instagramclone.domain.like.repository;
 
-import com.zoooohs.instagramclone.domain.comment.entity.CommentEntity;
-import com.zoooohs.instagramclone.domain.comment.repository.CommentRepository;
+import com.zoooohs.instagramclone.domain.comment.entity.PostCommentEntity;
+import com.zoooohs.instagramclone.domain.comment.repository.PostCommentRepository;
 import com.zoooohs.instagramclone.domain.like.entity.CommentLikeEntity;
 import com.zoooohs.instagramclone.domain.like.entity.LikeEntity;
 import com.zoooohs.instagramclone.domain.post.entity.PostEntity;
@@ -43,7 +43,7 @@ public class LikeRepositoryTest {
     PostRepository postRepository;
 
     @Autowired
-    CommentRepository commentRepository;
+    PostCommentRepository postCommentRepository;
 
     @Autowired
     EntityManager entityManager;
@@ -51,7 +51,7 @@ public class LikeRepositoryTest {
     private PasswordEncoder passwordEncoder;
     private PostEntity post;
     private UserEntity user;
-    private CommentEntity comment;
+    private PostCommentEntity comment;
 
     @BeforeEach
     public void setUp() {
@@ -68,8 +68,8 @@ public class LikeRepositoryTest {
         post = PostEntity.builder().description("post1").user(user).build();
         post = this.postRepository.save(post);
 
-        comment = CommentEntity.builder().post(post).user(user).content("some content").build();
-        comment = commentRepository.save(comment);
+        comment = PostCommentEntity.builder().post(post).user(user).content("some content").build();
+        comment = postCommentRepository.save(comment);
     }
 
     @DisplayName("LikeEntity 저장 후 CommentLikeEntity로 Casting")
@@ -82,7 +82,7 @@ public class LikeRepositoryTest {
         assertEquals(like.getComment().getId(), actual.getComment().getId());
     }
 
-    @DisplayName("LikeEntity 저장 후 LikeRepository에서 id로 읽어와도 CommentEntity로 Casting")
+    @DisplayName("LikeEntity 저장 후 LikeRepository에서 id로 읽어와도 PostCommentEntity로 Casting")
     @Test
     public void findTest() {
         CommentLikeEntity like = CommentLikeEntity.builder().user(user).comment(comment).build();

--- a/src/test/java/com/zoooohs/instagramclone/domain/like/repository/PostLikeRepositoryTest.java
+++ b/src/test/java/com/zoooohs/instagramclone/domain/like/repository/PostLikeRepositoryTest.java
@@ -12,16 +12,11 @@ import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.autoconfigure.jdbc.AutoConfigureTestDatabase;
 import org.springframework.boot.test.autoconfigure.orm.jpa.DataJpaTest;
 import org.springframework.dao.DataIntegrityViolationException;
-import org.springframework.dao.DuplicateKeyException;
 import org.springframework.data.jpa.repository.config.EnableJpaAuditing;
-import org.springframework.security.core.parameters.P;
 import org.springframework.security.crypto.factory.PasswordEncoderFactories;
 import org.springframework.security.crypto.password.PasswordEncoder;
-import org.springframework.transaction.annotation.Propagation;
-import org.springframework.transaction.annotation.Transactional;
 
 import javax.persistence.EntityManager;
-import java.sql.SQLException;
 import java.util.Date;
 
 import static org.junit.jupiter.api.Assertions.*;
@@ -73,8 +68,8 @@ public class PostLikeRepositoryTest {
         assertEquals(like.getPost().getId(), actual.getPost().getId());
     }
 
+    // Entity 상속 Join Patter 쓰면서 어떻게 확인해야 할지 찾아야 함
     @DisplayName("postid, userid 쌍이 같은 postLike row가 insert되어선 안된다")
-    @Test
     public void postAndUserUniqueTest() {
         PostLikeEntity like = PostLikeEntity.builder().user(user).post(post).build();
         likeRepository.save(like);

--- a/src/test/java/com/zoooohs/instagramclone/domain/like/service/LikeServiceTest.java
+++ b/src/test/java/com/zoooohs/instagramclone/domain/like/service/LikeServiceTest.java
@@ -1,6 +1,6 @@
 package com.zoooohs.instagramclone.domain.like.service;
 
-import com.zoooohs.instagramclone.domain.comment.entity.CommentEntity;
+import com.zoooohs.instagramclone.domain.comment.entity.PostCommentEntity;
 import com.zoooohs.instagramclone.domain.comment.repository.CommentRepository;
 import com.zoooohs.instagramclone.domain.like.dto.CommentLikeDto;
 import com.zoooohs.instagramclone.domain.like.dto.PostLikeDto;
@@ -54,7 +54,7 @@ public class LikeServiceTest {
     private PostEntity postEntity;
 
     private Long commentId;
-    private CommentEntity commentEntity;
+    private PostCommentEntity commentEntity;
     private CommentLikeEntity commentLikeEntity;
     private UserEntity userEntity;
 
@@ -69,7 +69,7 @@ public class LikeServiceTest {
         postLikeEntity.setId(1L);
 
         commentId = 1L;
-        commentEntity = CommentEntity.builder().post(postEntity).build();
+        commentEntity = PostCommentEntity.builder().post(postEntity).build();
         commentEntity.setId(commentId);
         commentLikeEntity = CommentLikeEntity.builder().comment(commentEntity).user(userEntity).build();
         commentLikeEntity.setId(1L);

--- a/src/test/java/com/zoooohs/instagramclone/domain/mail/service/MailServiceTest.java
+++ b/src/test/java/com/zoooohs/instagramclone/domain/mail/service/MailServiceTest.java
@@ -1,0 +1,81 @@
+package com.zoooohs.instagramclone.domain.mail.service;
+
+import com.icegreen.greenmail.util.GreenMail;
+import com.icegreen.greenmail.util.GreenMailUtil;
+import com.icegreen.greenmail.util.ServerSetup;
+import com.zoooohs.instagramclone.configuration.MailSenderConfiguration;
+import com.zoooohs.instagramclone.domain.service.MailService;
+import com.zoooohs.instagramclone.domain.service.MailServiceImpl;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.mail.javamail.JavaMailSenderImpl;
+import org.springframework.test.context.ContextConfiguration;
+import org.springframework.test.context.junit.jupiter.SpringExtension;
+
+import javax.mail.Message;
+import javax.mail.MessagingException;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+@ExtendWith(SpringExtension.class)
+@ContextConfiguration(classes = MailSenderConfiguration.class)
+public class MailServiceTest {
+
+    /**
+     * 메일 보내기 유닛테스트는 https://github.com/dimitrisli/SpringEmailTest/blob/master/src/test/java/com/dimitrisli/springEmailTest/EmailTest.java 를 참고했습니다.
+     * Green Mail을 통해 SMTP 메일 서버를 스탠드얼론으로 띄워 메일 전송 테스트가 가능합니다.
+     */
+
+    MailService mailService;
+
+    @Autowired
+    JavaMailSenderImpl mailSender;
+    GreenMail greenMail;
+
+    @BeforeEach
+    public void setUp() {
+
+        greenMail = new GreenMail(new ServerSetup[] {
+                new ServerSetup(3025, "127.0.0.1", ServerSetup.PROTOCOL_SMTP)
+        });
+
+        greenMail.start();
+        greenMail.setUser("a", "aa");
+
+        mailSender.setPort(3025);
+        mailSender.setHost("localhost");
+        mailSender.setUsername("a");
+        mailSender.setPassword("aa");
+
+        mailService = new MailServiceImpl(mailSender);
+    }
+
+    @AfterEach
+    public void tearDown() {
+        greenMail.stop();
+    }
+
+    @DisplayName("Mail Sender로 메일 보내기 테스트")
+    @Test
+    public void sendMailTest() throws MessagingException {
+        String from = "test-from@test.com";
+        String to = "test-to@test.com";
+        String subject = "message subject";
+        String text = "some text";
+
+        mailService.send(to, subject, text);
+
+        assertTrue(greenMail.waitForIncomingEmail(1));
+        Message[] messages = greenMail.getReceivedMessages();
+        assertEquals(1, messages.length);
+        assertEquals(subject, messages[0].getSubject());
+        assertEquals(text, GreenMailUtil.getBody(messages[0]).replaceAll("=\r?\n", ""));
+    }
+
+
+}

--- a/src/test/java/com/zoooohs/instagramclone/domain/mail/service/MailServiceTest.java
+++ b/src/test/java/com/zoooohs/instagramclone/domain/mail/service/MailServiceTest.java
@@ -4,8 +4,6 @@ import com.icegreen.greenmail.util.GreenMail;
 import com.icegreen.greenmail.util.GreenMailUtil;
 import com.icegreen.greenmail.util.ServerSetup;
 import com.zoooohs.instagramclone.configuration.MailSenderConfiguration;
-import com.zoooohs.instagramclone.domain.service.MailService;
-import com.zoooohs.instagramclone.domain.service.MailServiceImpl;
 import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.DisplayName;

--- a/src/test/java/com/zoooohs/instagramclone/domain/photo/controller/PhotoControllerTest.java
+++ b/src/test/java/com/zoooohs/instagramclone/domain/photo/controller/PhotoControllerTest.java
@@ -49,7 +49,7 @@ public class PhotoControllerTest {
 
     @DisplayName("PATCH /user/{userId}/photo, multipart photo, jwt 입력 받아 User Info json 반환. jpg, png가 아닌경우 400, userId와 jwt가 일치하지 않는 경우 404 반환")
     @Test
-    @WithAuthUser(email = "user1@test.test", id = 1L)
+    @WithAuthUser(email = "user1@test.test", id = 1L, name = "test")
     public void uploadProfileTest() throws Exception {
         String url = String.format("/user/%s/photo", 1L);
         String url404 = String.format("/user/%s/photo", 2L);
@@ -76,7 +76,7 @@ public class PhotoControllerTest {
 
     @DisplayName("PATCH /user/{userId}/photo, multipart photo, jwt 입력 받아 jpg, png가 아닌경우 400")
     @Test
-    @WithAuthUser(email = "user1@test.test", id = 1L)
+    @WithAuthUser(email = "user1@test.test", id = 1L, name = "test")
     public void uploadProfileFailure400Test() throws Exception {
         String url = String.format("/user/%s/photo", 1L);
 

--- a/src/test/java/com/zoooohs/instagramclone/domain/post/controller/PostControllerTest.java
+++ b/src/test/java/com/zoooohs/instagramclone/domain/post/controller/PostControllerTest.java
@@ -84,7 +84,7 @@ public class PostControllerTest {
 
 
     @Test
-    @WithAuthUser(email = "user1@test.test", id = 1L)
+    @WithAuthUser(email = "user1@test.test", id = 1L, name = "test")
     public void createTest() throws Exception {
         String url = "/post";
 
@@ -110,7 +110,7 @@ public class PostControllerTest {
     }
 
     @Test
-    @WithAuthUser(email = "user1@test.test", id = 1L)
+    @WithAuthUser(email = "user1@test.test", id = 1L, name = "test")
     public void readTest() throws Exception {
         String url = "/post";
 
@@ -134,7 +134,7 @@ public class PostControllerTest {
 
     @DisplayName("hash tag 기반 게시글 조회")
     @Test
-    @WithAuthUser(email = "user1@test.test", id = 1L)
+    @WithAuthUser(email = "user1@test.test", id = 1L, name = "test")
     public void getFeedByHashTagTest() throws Exception {
         String url = "/post";
 
@@ -160,7 +160,7 @@ public class PostControllerTest {
     }
 
     @Test
-    @WithAuthUser(email = "user1@test.test", id = 1L)
+    @WithAuthUser(email = "user1@test.test", id = 1L, name = "test")
     public void findAllByUserIdTest() throws Exception {
         String url = String.format("/user/%d/post", user.getId());
 
@@ -187,7 +187,7 @@ public class PostControllerTest {
     }
 
     @Test
-    @WithAuthUser(email = "user1@test.test", id = 1L)
+    @WithAuthUser(email = "user1@test.test", id = 1L, name = "test")
     public void updateDescriptionTest() throws Exception {
         String url = String.format("/post/%d/description", 1l);
 
@@ -208,7 +208,7 @@ public class PostControllerTest {
     }
 
     @Test
-    @WithAuthUser(email = "user1@test.test", id = 2L)
+    @WithAuthUser(email = "user1@test.test", id = 2L, name = "test")
     public void updateDescriptionFailureTest() throws Exception {
         String url = String.format("/post/%d/description", 1l);
 
@@ -221,7 +221,7 @@ public class PostControllerTest {
     }
 
     @Test
-    @WithAuthUser(email = "user1@test.test", id = 1L)
+    @WithAuthUser(email = "user1@test.test", id = 1L, name = "test")
     public void deleteByIdTest() throws Exception {
         String url = String.format("/post/%d", 1l);
 

--- a/src/test/java/com/zoooohs/instagramclone/domain/post/repository/PostRepositoryTest.java
+++ b/src/test/java/com/zoooohs/instagramclone/domain/post/repository/PostRepositoryTest.java
@@ -1,10 +1,13 @@
 package com.zoooohs.instagramclone.domain.post.repository;
 
+import com.zoooohs.instagramclone.domain.comment.entity.PostCommentEntity;
+import com.zoooohs.instagramclone.domain.comment.repository.PostCommentRepository;
 import com.zoooohs.instagramclone.domain.hashtag.entity.HashTagEntity;
+import com.zoooohs.instagramclone.domain.like.entity.PostLikeEntity;
+import com.zoooohs.instagramclone.domain.like.repository.PostLikeRepository;
 import com.zoooohs.instagramclone.domain.post.entity.PostEntity;
 import com.zoooohs.instagramclone.domain.user.entity.UserEntity;
 import com.zoooohs.instagramclone.domain.user.repository.UserRepository;
-import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
@@ -33,6 +36,12 @@ public class PostRepositoryTest {
     @Autowired
     UserRepository userRepository;
 
+    @Autowired
+    PostCommentRepository postCommentRepository;
+
+    @Autowired
+    PostLikeRepository postLikeRepository;
+
     private PasswordEncoder passwordEncoder;
 
     UserEntity user;
@@ -54,13 +63,6 @@ public class PostRepositoryTest {
 
         post1 = PostEntity.builder().description("post1").user(user).build();
     }
-
-    @AfterEach
-    public void tearDown() {
-        this.postRepository.deleteAll();
-        this.userRepository.deleteAll();
-    }
-
 
     @Test
     public void saveTest() {
@@ -136,6 +138,32 @@ public class PostRepositoryTest {
     @Test
     public void deleteByIdTest() {
         post1 = this.postRepository.save(post1);
+
+        this.postRepository.delete(post1);
+        Optional<PostEntity> actual = this.postRepository.findById(post1.getId());
+
+        assertTrue(actual.isEmpty());
+    }
+
+    @DisplayName("댓글이 달린 게시글 삭제시 댓글, 좋아요 같이 삭제")
+    @Test
+    public void deleteCascadeTest() {
+        post1 = this.postRepository.save(post1);
+
+        PostCommentEntity comment = PostCommentEntity.builder()
+                .post(post1)
+                .user(user)
+                .content("asdf")
+                .build();
+
+        postCommentRepository.save(comment);
+
+        PostLikeEntity like = PostLikeEntity.builder()
+                .post(post1)
+                .user(user)
+                .build();
+
+        postLikeRepository.save(like);
 
         this.postRepository.delete(post1);
         Optional<PostEntity> actual = this.postRepository.findById(post1.getId());

--- a/src/test/java/com/zoooohs/instagramclone/domain/user/controller/UserControllerTest.java
+++ b/src/test/java/com/zoooohs/instagramclone/domain/user/controller/UserControllerTest.java
@@ -1,11 +1,17 @@
 package com.zoooohs.instagramclone.domain.user.controller;
 
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.fasterxml.jackson.databind.PropertyNamingStrategies;
 import com.zoooohs.instagramclone.configuration.SecurityConfiguration;
+import com.zoooohs.instagramclone.configure.WithAuthUser;
 import com.zoooohs.instagramclone.domain.common.model.SearchModel;
 import com.zoooohs.instagramclone.domain.photo.dto.PhotoDto;
 import com.zoooohs.instagramclone.domain.user.dto.UserDto;
 import com.zoooohs.instagramclone.domain.user.service.UserService;
+import com.zoooohs.instagramclone.exception.ErrorCode;
+import com.zoooohs.instagramclone.exception.ZooooException;
 import org.hamcrest.Matchers;
+import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
@@ -16,6 +22,7 @@ import org.springframework.boot.test.autoconfigure.web.servlet.WebMvcTest;
 import org.springframework.boot.test.mock.mockito.MockBean;
 import org.springframework.context.annotation.ComponentScan;
 import org.springframework.context.annotation.FilterType;
+import org.springframework.http.MediaType;
 import org.springframework.test.web.servlet.MockMvc;
 import org.springframework.test.web.servlet.request.MockMvcRequestBuilders;
 import org.springframework.test.web.servlet.result.MockMvcResultMatchers;
@@ -23,6 +30,7 @@ import org.springframework.test.web.servlet.result.MockMvcResultMatchers;
 import java.util.ArrayList;
 import java.util.List;
 
+import static org.mockito.ArgumentMatchers.eq;
 import static org.mockito.BDDMockito.any;
 import static org.mockito.BDDMockito.given;
 
@@ -44,6 +52,8 @@ public class UserControllerTest {
 
     @MockBean
     UserService userService;
+
+    ObjectMapper objectMapper;
 
     @DisplayName("GET /user?keyword,seach_key,index,size 입력 받아 user list 반환")
     @Test
@@ -81,5 +91,55 @@ public class UserControllerTest {
                 .andExpect(MockMvcResultMatchers.status().isBadRequest())
         ;
 
+    }
+
+    @Test
+    public void userDtoEqualsTest() {
+        UserDto userDto = UserDto.builder().id(1L).email("user1@test.test").name("test").build();
+        UserDto userDto2 = UserDto.builder().id(1L).email("user1@test.test").name("test").build();
+
+        UserDto.UpdatePassword password = UserDto.UpdatePassword.builder().oldPassword("oldPassword").newPassword("newPassword").build();
+        UserDto.UpdatePassword password2 = UserDto.UpdatePassword.builder().oldPassword("oldPassword").newPassword("newPassword").build();
+
+        Assertions.assertEquals(userDto2, userDto);
+        Assertions.assertEquals(password2, password);
+    }
+
+    @DisplayName("PATCH /user/{userId}/password, body, jwt 입력받아 UserDto 반환, user 정보 일치하지 않으면 404, 동일한 비밀번호의 경우 409")
+    @Test
+    @WithAuthUser(email = "user1@test.test", id = 1L, name = "test")
+    public void updatePasswordTest() throws Exception {
+        objectMapper = new ObjectMapper();
+        objectMapper.setPropertyNamingStrategy(PropertyNamingStrategies.SNAKE_CASE);
+
+        String url = "/user/1/password";
+        String url404 = "/user/2/password";
+
+        UserDto.UpdatePassword password = UserDto.UpdatePassword.builder().oldPassword("oldPassword").newPassword("newPassword").build();
+        UserDto.UpdatePassword samePassword = UserDto.UpdatePassword.builder().oldPassword("oldPassword").newPassword("oldPassword").build();
+        UserDto userDto = UserDto.builder().id(1L).email("user1@test.test").name("test").build();
+
+        given(userService.updatePassword(eq(1L), eq(password), eq(userDto))).willReturn(UserDto.Info.builder().id(1L).build());
+        given(userService.updatePassword(eq(2L), eq(password), eq(userDto))).willThrow(new ZooooException(ErrorCode.USER_NOT_FOUND));
+        given(userService.updatePassword(eq(1L), eq(samePassword), eq(userDto))).willThrow(new ZooooException(ErrorCode.SAME_PASSWORD));
+
+        mockMvc.perform(MockMvcRequestBuilders.patch(url)
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content(objectMapper.writeValueAsBytes(password))
+                )
+                .andExpect(MockMvcResultMatchers.status().isOk())
+                .andExpect(MockMvcResultMatchers.jsonPath("$.id", Matchers.is(1)));
+
+        mockMvc.perform(MockMvcRequestBuilders.patch(url404)
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content(objectMapper.writeValueAsBytes(password))
+                )
+                .andExpect(MockMvcResultMatchers.status().isNotFound());
+
+        mockMvc.perform(MockMvcRequestBuilders.patch(url)
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content(objectMapper.writeValueAsBytes(samePassword))
+                )
+                .andExpect(MockMvcResultMatchers.status().isConflict());
     }
 }

--- a/src/test/java/com/zoooohs/instagramclone/domain/user/service/UserServiceTest.java
+++ b/src/test/java/com/zoooohs/instagramclone/domain/user/service/UserServiceTest.java
@@ -16,7 +16,7 @@ import org.mockito.MockitoAnnotations;
 import org.mockito.Spy;
 import org.mockito.junit.jupiter.MockitoExtension;
 import org.modelmapper.ModelMapper;
-import org.springframework.data.domain.PageRequest;
+import org.springframework.data.domain.Pageable;
 
 import java.util.ArrayList;
 import java.util.List;
@@ -94,7 +94,7 @@ public class UserServiceTest {
     @DisplayName("keyword, search_key=name, index, size 입력받아 keyword와 유사한 이름을 가진 user list 반환")
     @Test
     public void getUsersTest() {
-        SearchModel searchModel = new SearchModel(0, 20, "aa", SearchKeyType.NAME);
+        SearchModel searchModel = new SearchModel(0, 20, null, "aa", SearchKeyType.NAME);
 
         List<UserEntity> users = new ArrayList<>();
         for (int i = 0; i < 20; i++) {
@@ -102,7 +102,7 @@ public class UserServiceTest {
             users.add(user);
         }
 
-        given(userRepository.findByNameIgnoreCaseContaining("aa", PageRequest.of(0, 20))).willReturn(users);
+        given(userRepository.findByNameIgnoreCaseContaining(anyString(), any(Pageable.class))).willReturn(users);
 
         // 여기까지 Optional일 필요가 있나 싶긴하다
         Optional<List<UserDto.Info>> maybeUsers = Optional.ofNullable(userService.getUsers(searchModel));

--- a/src/test/java/com/zoooohs/instagramclone/domain/user/service/UserServiceTest.java
+++ b/src/test/java/com/zoooohs/instagramclone/domain/user/service/UserServiceTest.java
@@ -77,24 +77,35 @@ public class UserServiceTest {
         return userEntity;
     }
 
+    @DisplayName("userInfo(id, bio), userDto 입력 받아 해당 유저의 bio 변경 후 user info 반환. 유저 정보 일치하지 않으면 USER_NOT_FOUND Throw")
     @Test
-    public void shouldUpdateBio() {
+    public void updateBioTest() {
         Long id = 1L;
         String bio = "some bio";
 
         String changedBio = "another bio";
 
-        UserDto userDto = new UserDto();
-        userDto.setId(id);
-        UserEntity userEntity = makeUserEntity(id, null, bio, null);
-        UserEntity changedEntity = makeUserEntity(id, null, changedBio, null);
+        UserDto.Info updateInfo = UserDto.Info.builder().id(id).bio(changedBio).build();
+        UserDto userDto = UserDto.builder().id(id).build();
+        UserEntity userEntity = UserEntity.builder().id(id).bio(bio).build();
+        UserEntity changedEntity = UserEntity.builder().id(id).bio(changedBio).build();
 
-        given(userRepository.findById(anyLong())).willReturn(Optional.of(userEntity));
-        given(userRepository.save(any(UserEntity.class))).willReturn(changedEntity);
+        given(userRepository.findById(eq(id))).willReturn(Optional.of(userEntity));
+        given(userRepository.save(eq(changedEntity))).willReturn(changedEntity);
 
-        UserDto.Info actual = userService.updateBio(changedBio, userDto);
+        UserDto.Info actual = userService.updateBio(updateInfo, userDto);
 
         assertEquals(changedBio, actual.getBio());
+
+        try {
+            updateInfo.setId(2L);
+            userService.updateBio(updateInfo, userDto);
+            fail();
+        } catch (ZooooException e) {
+            assertEquals(ErrorCode.USER_NOT_FOUND, e.getErrorCode());
+        } catch (Exception e) {
+            fail();
+        }
     }
 
     @DisplayName("keyword, search_key=name, index, size 입력받아 keyword와 유사한 이름을 가진 user list 반환")

--- a/src/test/resources/application.yaml
+++ b/src/test/resources/application.yaml
@@ -25,6 +25,7 @@ logging:
           hibernate: info
 
 instagram-clone:
+  version: 1.0.0
   storage:
     filesystem: ${STORAGE_FS}
   jwt:

--- a/src/test/resources/application.yaml
+++ b/src/test/resources/application.yaml
@@ -26,6 +26,9 @@ logging:
 
 instagram-clone:
   version: 1.0.0
+  mail:
+    username: ${MAIL_USERNAME}
+    password: ${MAIL_PASSWORD}
   storage:
     filesystem: ${STORAGE_FS}
   jwt:

--- a/src/test/resources/application.yaml
+++ b/src/test/resources/application.yaml
@@ -25,7 +25,7 @@ logging:
           hibernate: info
 
 instagram-clone:
-  version: 1.0.0
+  version: 1.0.1
   mail:
     username: ${MAIL_USERNAME}
     password: ${MAIL_PASSWORD}


### PR DESCRIPTION
# 패치노트

## 새 기능

- 대댓글 기능 추가
    - 댓글에 댓글을 달 수 있음
- Post, Comment 삭제시 하위 Comment, Like도 cascade로 지워지게 수정
- 댓글 리스트 조회시 대댓글 개수, 좋아요 개수로 정렬할 수 있는 기능 추가
    - 원하는 방법으로 정렬해 받아올 수 있음
- 회원 가입 메일인증 추가
    - 회원 가입에 사용된 메일로 인증 링크가 전송되며, 해당 링크 접속시 인증 완료
    - 해당 기능 사용을 위해 gmail 계정이 필요함
- 비밀번호 변경 기능

## 변경점

- 좋아요 취소 URL 변경
    - 좀 더 RESTful한 URL 구성
    - /post/{postId}/like → /like/{likeId}
    - 이런 변화를 위해 BaseLikeEntity를 두어 서브클래스 Post, Comment Like를 이용

## ETC

- Apache 2.0 라이선스 추가