### PR TITLE
1.0.2

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -41,3 +41,7 @@ out/
 .elasticbeanstalk/*
 !.elasticbeanstalk/*.cfg.yml
 !.elasticbeanstalk/*.global.yml
+
+
+# build 부속물
+app.zip

--- a/.platform/nginx/conf.d/elasticbeanstalk/increase-max-body.conf
+++ b/.platform/nginx/conf.d/elasticbeanstalk/increase-max-body.conf
@@ -1,0 +1,1 @@
+client_max_body_size 40M;

--- a/Makefile
+++ b/Makefile
@@ -1,0 +1,12 @@
+eb:
+	rm -f build/libs/*
+	./gradlew bootJar
+	cp build/libs/*.jar application.jar
+	zip app.zip application.jar -r .ebextensions/** -r .platform/** Procfile
+	rm application.jar
+	eb deploy --staged
+
+
+clean:
+	rm -f build/libs/*
+	rm app.zip

--- a/Procfile
+++ b/Procfile
@@ -1,0 +1,1 @@
+web: java -Dfile.encoding=UTF-8 -jar application.jar

--- a/build.gradle
+++ b/build.gradle
@@ -23,6 +23,7 @@ dependencies {
 	implementation 'org.springframework.boot:spring-boot-starter-data-jpa'
 	implementation 'org.springframework.boot:spring-boot-starter-web'
 	implementation 'org.springframework.boot:spring-boot-starter-security'
+	implementation 'org.springframework.boot:spring-boot-starter-actuator'
 	implementation 'org.springframework.security:spring-security-test'
 	implementation 'org.springframework.cloud:spring-cloud-starter-aws:2.2.6.RELEASE'
 	implementation group: 'io.jsonwebtoken', name: 'jjwt', version: '0.9.1'

--- a/src/main/java/com/zoooohs/instagramclone/configuration/JwtTokenProvider.java
+++ b/src/main/java/com/zoooohs/instagramclone/configuration/JwtTokenProvider.java
@@ -64,6 +64,7 @@ public class JwtTokenProvider {
         claims.put("name", userDto.getName());
         claims.put("bio", userDto.getBio());
         claims.put("photo", userDto.getPhoto());
+        claims.put("id", userDto.getId());
         Instant now = Instant.now();
         return Jwts.builder()
                 .setClaims(claims)

--- a/src/main/java/com/zoooohs/instagramclone/configuration/SecurityConfiguration.java
+++ b/src/main/java/com/zoooohs/instagramclone/configuration/SecurityConfiguration.java
@@ -47,6 +47,8 @@ public class SecurityConfiguration extends WebSecurityConfigurerAdapter {
                 .sessionCreationPolicy(SessionCreationPolicy.STATELESS)
                 .and()
                 .authorizeRequests()
+                .antMatchers("/actuator/health").permitAll()
+                .antMatchers("/actuator/**").hasRole("ADMIN")
                 .antMatchers("/auth/**").permitAll()
                 .antMatchers("/v3/api-docs/**").permitAll()
                 .antMatchers("/swagger-ui/**").permitAll()

--- a/src/main/java/com/zoooohs/instagramclone/configuration/WebConfig.java
+++ b/src/main/java/com/zoooohs/instagramclone/configuration/WebConfig.java
@@ -1,17 +1,23 @@
 package com.zoooohs.instagramclone.configuration;
 
+import org.springframework.beans.factory.annotation.Value;
 import org.springframework.context.annotation.Configuration;
-import org.springframework.context.annotation.Profile;
 import org.springframework.web.servlet.config.annotation.CorsRegistry;
 import org.springframework.web.servlet.config.annotation.WebMvcConfigurer;
 
-@Profile("local")
 @Configuration
 public class WebConfig implements WebMvcConfigurer {
+
+    @Value("${instagram-clone.cors.allow-url:none}")
+    private String allowUrl;
+
     @Override
     public void addCorsMappings(CorsRegistry registry) {
+        if (this.allowUrl.equals("none")) {
+            return;
+        }
         registry.addMapping("/**")
-                .allowedOrigins("*")
+                .allowedOrigins(allowUrl)
                 .allowedMethods("*")
                 .maxAge(3000);
     }

--- a/src/main/java/com/zoooohs/instagramclone/domain/auth/dto/AuthDto.java
+++ b/src/main/java/com/zoooohs/instagramclone/domain/auth/dto/AuthDto.java
@@ -55,7 +55,9 @@ public class AuthDto {
     @Schema(name = "AuthDto.Token")
     @Getter
     @Setter
+    @Builder
     @NoArgsConstructor
+    @AllArgsConstructor
     public static class Token {
         @Pattern(regexp = Patterns.JWT)
         @NotNull
@@ -64,11 +66,5 @@ public class AuthDto {
         @Pattern(regexp = Patterns.JWT)
         @NotNull
         private String refreshToken;
-
-        @Builder
-        public Token(String accessToken, String refreshToken) {
-            this.accessToken = accessToken;
-            this.refreshToken = refreshToken;
-        }
     }
 }

--- a/src/main/java/com/zoooohs/instagramclone/domain/comment/dto/CommentDto.java
+++ b/src/main/java/com/zoooohs/instagramclone/domain/comment/dto/CommentDto.java
@@ -8,6 +8,7 @@ import lombok.NoArgsConstructor;
 import lombok.experimental.Accessors;
 
 import javax.validation.constraints.NotNull;
+import java.time.LocalDateTime;
 
 @Data
 @NoArgsConstructor
@@ -28,8 +29,13 @@ public class CommentDto {
     @Schema(name = "liked", description = "내가 좋아요를 눌렀는지 여부")
     private Boolean isLiked;
 
+    @Schema(name = "likedId", description = "내가 누른 좋아요 id")
+    private Long likedId;
+
     @Schema(description = "대댓글 개수")
     private Long commentCount;
+
+    private LocalDateTime createdAt;
 
     @Builder
     public CommentDto(Long id, String content, UserDto.Feed user, Long likeCount, Boolean isLiked, Long commentCount) {

--- a/src/main/java/com/zoooohs/instagramclone/domain/comment/repository/PostCommentRepository.java
+++ b/src/main/java/com/zoooohs/instagramclone/domain/comment/repository/PostCommentRepository.java
@@ -18,10 +18,13 @@ public interface PostCommentRepository extends JpaRepository<PostCommentEntity, 
     PostCommentEntity findByIdAndUserId(Long commentId, Long userId);
 
     @EntityGraph("comment-user")
-    @Query("SELECT c FROM post_comment c WHERE c.post.id = :id ORDER BY c.likes.size DESC")
+    @Query("SELECT c FROM post_comment c WHERE c.post.id = :id ORDER BY c.likes.size DESC, c.id")
     List<PostCommentEntity> findPostCommentsOrderByLikesSize(@Param("id") Long id, Pageable pageable);
 
     @EntityGraph("comment-user")
-    @Query("SELECT c FROM post_comment c WHERE c.post.id = :id ORDER BY c.comments.size DESC")
+    @Query("SELECT c FROM post_comment c WHERE c.post.id = :id ORDER BY c.comments.size DESC, c.id")
     List<PostCommentEntity> findPostCommentsOrderByCommentsSize(@Param("id") Long id, Pageable pageable);
+
+    @EntityGraph("comment-user")
+    List<PostCommentEntity> findByPostIdOrderByIdDesc(Long postId, Pageable of);
 }

--- a/src/main/java/com/zoooohs/instagramclone/domain/comment/service/CommentServiceImpl.java
+++ b/src/main/java/com/zoooohs/instagramclone/domain/comment/service/CommentServiceImpl.java
@@ -61,7 +61,7 @@ public class CommentServiceImpl implements CommentService {
         PostEntity post = this.postRepository.findById(postId).orElseThrow(() -> new ZooooException(ErrorCode.POST_NOT_FOUND));
         List<PostCommentEntity> comments;
         if (pageModel.getSortKey() == null) {
-            comments = this.postCommentRepository.findByPostId(post.getId(), PageRequest.of(pageModel.getIndex(), pageModel.getSize()));
+            comments = this.postCommentRepository.findByPostIdOrderByIdDesc(post.getId(), PageRequest.of(pageModel.getIndex(), pageModel.getSize()));
         }
         else {
             switch (pageModel.getSortKey()) {
@@ -72,7 +72,7 @@ public class CommentServiceImpl implements CommentService {
                     comments = postCommentRepository.findPostCommentsOrderByCommentsSize(post.getId(), PageRequest.of(pageModel.getIndex(), pageModel.getSize()));
                     break;
                 default:
-                    comments = this.postCommentRepository.findByPostId(post.getId(), PageRequest.of(pageModel.getIndex(), pageModel.getSize()));
+                    comments = this.postCommentRepository.findByPostIdOrderByIdDesc(post.getId(), PageRequest.of(pageModel.getIndex(), pageModel.getSize()));
             }
         }
         return comments.stream().map(entity -> {

--- a/src/main/java/com/zoooohs/instagramclone/domain/comment/service/CommentServiceImpl.java
+++ b/src/main/java/com/zoooohs/instagramclone/domain/comment/service/CommentServiceImpl.java
@@ -8,6 +8,7 @@ import com.zoooohs.instagramclone.domain.comment.repository.CommentCommentReposi
 import com.zoooohs.instagramclone.domain.comment.repository.CommentRepository;
 import com.zoooohs.instagramclone.domain.comment.repository.PostCommentRepository;
 import com.zoooohs.instagramclone.domain.common.model.PageModel;
+import com.zoooohs.instagramclone.domain.like.entity.LikeEntity;
 import com.zoooohs.instagramclone.domain.post.entity.PostEntity;
 import com.zoooohs.instagramclone.domain.post.repository.PostRepository;
 import com.zoooohs.instagramclone.domain.user.dto.UserDto;
@@ -108,8 +109,9 @@ public class CommentServiceImpl implements CommentService {
 
     private CommentDto makeCommentDto(Long userId, CommentEntity commentEntity) {
         CommentDto dto = this.modelMapper.map(commentEntity, CommentDto.class);
-        boolean isLiked = commentEntity.getLikes().stream().filter(like -> like.getUser().getId().equals(userId)).findFirst().isPresent();
-        dto.isLiked(isLiked);
+        Long likedId = commentEntity.getLikes().stream().filter(like -> like.getUser().getId().equals(userId)).findFirst().map(LikeEntity::getId).orElse(null);
+        dto.setLikedId(likedId);
+        dto.isLiked(likedId != null);
         return dto;
     }
 

--- a/src/main/java/com/zoooohs/instagramclone/domain/post/dto/PostDto.java
+++ b/src/main/java/com/zoooohs/instagramclone/domain/post/dto/PostDto.java
@@ -7,6 +7,7 @@ import lombok.*;
 import lombok.experimental.Accessors;
 
 import javax.validation.constraints.NotNull;
+import java.time.LocalDateTime;
 import java.util.List;
 
 public class PostDto {
@@ -36,7 +37,12 @@ public class PostDto {
         @Schema(name = "liked", description = "내가 좋아요를 눌렀는지 여부")
         private Boolean isLiked;
 
+        @Schema(name = "likedId", description = "내가 누른 좋아요 id")
+        private Long likedId;
+
         @Schema(description = "게시글 댓글 개수")
         private Long commentCount;
+
+        private LocalDateTime createdAt;
     }
 }

--- a/src/main/java/com/zoooohs/instagramclone/domain/post/dto/PostDto.java
+++ b/src/main/java/com/zoooohs/instagramclone/domain/post/dto/PostDto.java
@@ -3,9 +3,7 @@ package com.zoooohs.instagramclone.domain.post.dto;
 import com.zoooohs.instagramclone.domain.photo.dto.PhotoDto;
 import com.zoooohs.instagramclone.domain.user.dto.UserDto;
 import io.swagger.v3.oas.annotations.media.Schema;
-import lombok.Builder;
-import lombok.Data;
-import lombok.NoArgsConstructor;
+import lombok.*;
 import lombok.experimental.Accessors;
 
 import javax.validation.constraints.NotNull;
@@ -13,7 +11,10 @@ import java.util.List;
 
 public class PostDto {
     @Schema(name = "PostDto.Post")
-    @Data
+    @Getter
+    @Setter
+    @Builder
+    @AllArgsConstructor
     @NoArgsConstructor
     public static class Post {
         private Long id;
@@ -35,14 +36,7 @@ public class PostDto {
         @Schema(name = "liked", description = "내가 좋아요를 눌렀는지 여부")
         private Boolean isLiked;
 
-        @Builder
-        public Post(Long id, String description, List<PhotoDto.Photo> photos, UserDto.Feed user, Long likeCount, Boolean isLiked) {
-            this.id = id;
-            this.description = description;
-            this.photos = photos;
-            this.user = user;
-            this.likeCount = likeCount;
-            this.isLiked = isLiked;
-        }
+        @Schema(description = "게시글 댓글 개수")
+        private Long commentCount;
     }
 }

--- a/src/main/java/com/zoooohs/instagramclone/domain/post/entity/PostEntity.java
+++ b/src/main/java/com/zoooohs/instagramclone/domain/post/entity/PostEntity.java
@@ -55,6 +55,9 @@ public class PostEntity extends BaseEntity {
     public Long getLikeCount() {
         return (long) likes.size();
     }
+    public Long getCommentCount() {
+        return (long) comments.size();
+    }
 
     public void setHashTags(Set<HashTagEntity> hashTags) {
         this.hashTags.clear();

--- a/src/main/java/com/zoooohs/instagramclone/domain/post/repository/PostRepository.java
+++ b/src/main/java/com/zoooohs/instagramclone/domain/post/repository/PostRepository.java
@@ -25,6 +25,10 @@ public interface PostRepository extends JpaRepository<PostEntity, Long> {
     PostEntity findByIdAndUserId(Long postId, Long userId);
 
     @EntityGraph("post-feed")
+    @Query("SELECT p FROM PostEntity p ORDER BY p.id DESC")
+    List<PostEntity> findAllWithPage(Pageable pageable);
+
+    @EntityGraph("post-feed")
     @Query("SELECT p FROM PostEntity p WHERE p.user.id = :userId ORDER BY p.id DESC")
     List<PostEntity> findMinesAndFollowUsers(Long userId, Pageable pageable);
 

--- a/src/main/java/com/zoooohs/instagramclone/domain/post/service/PostServiceImpl.java
+++ b/src/main/java/com/zoooohs/instagramclone/domain/post/service/PostServiceImpl.java
@@ -1,6 +1,5 @@
 package com.zoooohs.instagramclone.domain.post.service;
 
-import com.zoooohs.instagramclone.domain.common.entity.BaseEntity;
 import com.zoooohs.instagramclone.domain.common.model.PageModel;
 import com.zoooohs.instagramclone.domain.common.model.SearchModel;
 import com.zoooohs.instagramclone.domain.common.type.SearchKeyType;
@@ -108,9 +107,12 @@ public class PostServiceImpl implements PostService {
     public List<PostDto.Post> getFeeds(Long userId, SearchModel searchModel) {
         List<PostEntity> postEntities = null;
         if (searchModel.getKeyword() == null) {
-            List<Long> userIds = followRepository.findByUserId(userId).stream().map(entity -> entity.getFollowUser().getId()).collect(Collectors.toList());
-            userIds.add(userId);
-            postEntities = postRepository.findAllByUserId(userIds, PageRequest.of(searchModel.getIndex(), searchModel.getSize()));
+            // 일단 팔로워 붙기 전까진 전체 게시글 보기
+            // TODO: findAllWithPage UnitTest
+            postEntities = postRepository.findAllWithPage(PageRequest.of(searchModel.getIndex(), searchModel.getSize()));
+//            List<Long> userIds = followRepository.findByUserId(userId).stream().map(entity -> entity.getFollowUser().getId()).collect(Collectors.toList());
+//            userIds.add(userId);
+//            postEntities = postRepository.findAllByUserId(userIds, PageRequest.of(searchModel.getIndex(), searchModel.getSize()));
         } else {
             if (searchModel.getSearchKey().equals(SearchKeyType.HASH_TAG)) {
                 postEntities = postRepository.findAllByTag(searchModel.getKeyword(), PageRequest.of(searchModel.getIndex(), searchModel.getSize()));

--- a/src/main/java/com/zoooohs/instagramclone/domain/user/dto/UserDto.java
+++ b/src/main/java/com/zoooohs/instagramclone/domain/user/dto/UserDto.java
@@ -21,17 +21,15 @@ public class UserDto {
     }
 
     @Schema(name = "UserDto.Feed", description = "게시글 피드 리스트에 유저 정보를 나타내기 위한 DTO")
-    @Data
+    @Getter
+    @Setter
+    @Builder
     @NoArgsConstructor
+    @AllArgsConstructor
     public static class Feed {
         private Long id;
         private String name;
-
-        @Builder
-        public Feed(Long id, String name) {
-            this.id = id;
-            this.name = name;
-        }
+        private PhotoDto.Photo photo;
     }
 
     @Schema(name = "UserDto.Info", description = "유저 세부 정보를 나타내기 위한 DTO")

--- a/src/main/java/com/zoooohs/instagramclone/domain/user/entity/UserEntity.java
+++ b/src/main/java/com/zoooohs/instagramclone/domain/user/entity/UserEntity.java
@@ -21,7 +21,7 @@ import java.util.Collection;
                 @NamedAttributeNode("photo")
         })
 })
-@EqualsAndHashCode(of = {"name", "email", "id"})
+@EqualsAndHashCode(of = {"name", "email"})
 public class UserEntity extends BaseEntity implements UserDetails {
 
     @Email

--- a/src/main/resources/application.yaml
+++ b/src/main/resources/application.yaml
@@ -36,6 +36,9 @@ spring:
 #    local profile에 쓸 property yaml 추가
 #    import:
 #      - application-some-property-local.yaml
+instagram-clone:
+  cors:
+    allow-url: "*"
 ---
 spring:
   config:
@@ -44,5 +47,11 @@ spring:
 #    prod profile에 쓸 property yaml 추가
 #    import:
 #      - application-some-property-prod.yaml
+instagram-clone:
+  cors:
+    # 환경에 맞는 static web host를 입력
+    allow-url: http://zoooo-hs-ic-static.s3-website.ap-northeast-2.amazonaws.com
 server:
   port: 5000 # aws elastic beanstalk
+  servlet:
+    contextPath: /api

--- a/src/test/java/com/zoooohs/instagramclone/domain/comment/service/CommentServiceTest.java
+++ b/src/test/java/com/zoooohs/instagramclone/domain/comment/service/CommentServiceTest.java
@@ -138,7 +138,9 @@ public class CommentServiceTest {
                     .content("content " + i)
                     .user(UserEntity.builder().name("user"+1).id((long) i).build())
                     .build();
+            commentEntity.setId((long) i*i);
             CommentLikeEntity commentLike = new CommentLikeEntity();
+            commentLike.setId((long) i);
             commentLike.setComment(commentEntity);
             commentLike.setUser(UserEntity.builder().id(userDto.getId()).build());
             commentEntities.add(commentEntity);
@@ -148,7 +150,7 @@ public class CommentServiceTest {
         }
 
         given(this.postRepository.findById(postId)).willReturn(Optional.ofNullable(post));
-        given(postCommentRepository.findByPostId(eq(postId), any(Pageable.class))).willReturn(commentEntities);
+        given(postCommentRepository.findByPostIdOrderByIdDesc(eq(postId), any(Pageable.class))).willReturn(commentEntities);
 
         List<CommentDto> actual = this.commentService.getPostCommentList(postId, pageModel, userDto.getId());
 
@@ -156,6 +158,7 @@ public class CommentServiceTest {
         assertTrue(actual.size() <= pageModel.getSize());
         assertNotNull(actual.get(0).getLikeCount());
         assertTrue(actual.get(0).isLiked());
+        assertNotNull(actual.get(0).getLikedId());
     }
 
     @DisplayName("commentId 입력 받아 comment comment list 반환하는 service 테스트")
@@ -173,7 +176,9 @@ public class CommentServiceTest {
                     .content("content " + i)
                     .user(UserEntity.builder().name("user"+1).id((long) i).build())
                     .build();
+            commentEntity.setId((long)i*i);
             CommentLikeEntity commentLike = new CommentLikeEntity();
+            commentLike.setId((long) i);
             commentLike.setComment(commentEntity);
             commentLike.setUser(UserEntity.builder().id(userDto.getId()).build());
             commentEntities.add(commentEntity);
@@ -191,6 +196,7 @@ public class CommentServiceTest {
         assertTrue(actual.size() <= pageModel.getSize());
         assertNotNull(actual.get(0).getLikeCount());
         assertTrue(actual.get(0).isLiked());
+        assertNotNull(actual.get(0).getLikedId());
     }
 
     @DisplayName("없는 postId의 경우 POST_NOT_FOUND Exception throw 하는 service테스트")

--- a/src/test/java/com/zoooohs/instagramclone/domain/photo/service/PhotoServiceTest.java
+++ b/src/test/java/com/zoooohs/instagramclone/domain/photo/service/PhotoServiceTest.java
@@ -24,10 +24,7 @@ import org.springframework.test.context.TestPropertySource;
 import org.springframework.web.multipart.MultipartFile;
 
 import java.io.File;
-import java.util.ArrayList;
-import java.util.List;
-import java.util.Optional;
-import java.util.UUID;
+import java.util.*;
 
 import static org.junit.jupiter.api.Assertions.*;
 import static org.mockito.BDDMockito.anyList;
@@ -94,6 +91,19 @@ public class PhotoServiceTest {
         for (PhotoDto.Photo photo: actual) {
             assertTrue(photo.getId() != null);
         }
+    }
+
+    @DisplayName("compareTo Test")
+    @Test
+    void compareToTest() {
+       photoEntities.sort(new Comparator<PhotoEntity>() {
+           @Override
+           public int compare(PhotoEntity o1, PhotoEntity o2) {
+               return o1.getId().compareTo(o2.getId());
+           }
+       });
+
+       assertTrue(photoEntities.get(0).getId() < photoEntities.get(1).getId());
     }
 
     @DisplayName("userId, Multipartfile 받아 photo 저장, photo entity 저장, user entity에 photo 연결 후 photo 반환")

--- a/src/test/java/com/zoooohs/instagramclone/domain/post/controller/PostControllerTest.java
+++ b/src/test/java/com/zoooohs/instagramclone/domain/post/controller/PostControllerTest.java
@@ -117,7 +117,7 @@ public class PostControllerTest {
         List<PostDto.Post> postDtos = new ArrayList<>();
 
         for (int i = 0; i < 10; i++) {
-            PostDto.Post postDto = PostDto.Post.builder().id((long)i).description("a").isLiked(true).likeCount((long)10).build();
+            PostDto.Post postDto = PostDto.Post.builder().id((long)i).description("a").isLiked(true).likeCount((long)10).commentCount((long) 2).build();
             postDtos.add(postDto);
         }
 
@@ -129,6 +129,7 @@ public class PostControllerTest {
                 .andExpect(MockMvcResultMatchers.status().isOk())
                 .andExpect(MockMvcResultMatchers.jsonPath("$[0].like_count", Matchers.instanceOf(Integer.class)))
                 .andExpect(MockMvcResultMatchers.jsonPath("$[0].liked", Matchers.instanceOf(Boolean.class)))
+                .andExpect(MockMvcResultMatchers.jsonPath("$[0].comment_count", Matchers.instanceOf(Integer.class)))
         ;
     }
 
@@ -191,7 +192,7 @@ public class PostControllerTest {
     public void updateDescriptionTest() throws Exception {
         String url = String.format("/post/%d/description", 1l);
 
-        given(postService.updateDescription(anyLong(), eq(post), any(UserDto.class))).willReturn(post);
+        given(postService.updateDescription(eq(1L), any(PostDto.Post.class), any(UserDto.class))).willReturn(post);
 
         mockMvc.perform(MockMvcRequestBuilders.patch(url)
                 .contentType(MediaType.APPLICATION_JSON)

--- a/src/test/java/com/zoooohs/instagramclone/domain/post/service/PostServiceTest.java
+++ b/src/test/java/com/zoooohs/instagramclone/domain/post/service/PostServiceTest.java
@@ -126,8 +126,10 @@ public class PostServiceTest {
         searchModel.setSize(20);
 
 
-        given(followRepository.findByUserId(eq(user.getId()))).willReturn(followEntities);
-        given(this.postRepository.findAllByUserId(anyList(), eq(PageRequest.of(0, 20)))).willReturn(posts.subList(0, 20));
+        // TODO: 일단 테스트를 위해 전체 리스트 조회
+//        given(followRepository.findByUserId(eq(user.getId()))).willReturn(followEntities);
+//        given(this.postRepository.findAllByUserId(anyList(), eq(PageRequest.of(0, 20)))).willReturn(posts.subList(0, 20));
+        given(this.postRepository.findAllWithPage(eq(PageRequest.of(0, 20)))).willReturn(posts.subList(0, 20));
 
         List<PostDto.Post> actual = postService.getFeeds(user.getId(), searchModel);
 


### PR DESCRIPTION
# frontend와 맞춰보며 API 로직 일부 수정
- JWT claim에 user id 추가
- Post 반환할 때, Photo list는 photo id 오름차순 정렬
- 댓글 리스트 id 오름차순 정렬
- Like 반환시 id전달하여 dislike 가능하도록
- 게시글 리스트 받아오기 -> 임시적으로 팔로워 아닌 전체 게시글 받아오게 수정

 
# s3로 static web host를 하면서 eb에 올린 backend와 연동하기 위해 바뀐 점
- actuator 추가
  - eb health check에서 5xx 에러 발생하던 문제 수정
- eb 배포를 위한 스크립트 및 설정 파일 추가
- s3 url에 맞춰 cors 예외를 주기 위해 properties 로 url 받아옴   